### PR TITLE
Created rust-toolchain for drasi server

### DIFF
--- a/.github/workflows/integration-test-getting-started.yml
+++ b/.github/workflows/integration-test-getting-started.yml
@@ -49,10 +49,8 @@ jobs:
       - name: Set JQ_LIB_DIR
         run: echo "JQ_LIB_DIR=/usr/lib/x86_64-linux-gnu" >> $GITHUB_ENV
 
-      - name: Install specific Rust version
-        run: |
-          rustup update 1.88.0
-          rustup default 1.88.0
+      - name: Install Rust toolchain
+        run: rustup show
 
       - name: Setup PostgreSQL database
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,11 +30,8 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libjq-dev libonig-dev protobuf-compiler
 
-      - name: Install specific Rust version
-        run: |
-          rustup update 1.88.0
-          rustup default 1.88.0
-          rustup component add rustfmt
+      - name: Install Rust toolchain
+        run: rustup show
 
       - name: Check formatting
         run: make fmt-check
@@ -54,11 +51,8 @@ jobs:
       - name: Set JQ_LIB_DIR
         run: echo "JQ_LIB_DIR=/usr/lib/x86_64-linux-gnu" >> $GITHUB_ENV
 
-      - name: Install specific Rust version
-        run: |
-          rustup update 1.88.0
-          rustup default 1.88.0
-          rustup component add clippy
+      - name: Install Rust toolchain
+        run: rustup show
 
       - name: Run clippy
         run: make clippy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,8 @@ jobs:
       - name: Set JQ_LIB_DIR
         run: echo "JQ_LIB_DIR=/usr/lib/x86_64-linux-gnu" >> $GITHUB_ENV
 
-      - name: Install specific Rust version
-        run: |
-          rustup update 1.88.0
-          rustup default 1.88.0
+      - name: Install Rust toolchain
+        run: rustup show
 
       - name: Run tests
         run: make test

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.88.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
When working locally, to clean up a previous installation (this only needs to be run once), run the following command:

```bash
rustup toolchain uninstall 1.88.0-aarch64-apple-darwin
```