### PR TITLE
Fix Linux cross-build failures by upgrading base image to Ubuntu 22.04

### DIFF
--- a/Dockerfile.cross-gnu
+++ b/Dockerfile.cross-gnu
@@ -1,6 +1,6 @@
 FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5 AS toolchain
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # Copy runner scripts from the cross image
 COPY --from=toolchain /linux-runner /linux-runner

--- a/Dockerfile.cross-gnu-aarch64
+++ b/Dockerfile.cross-gnu-aarch64
@@ -1,6 +1,6 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.5 AS toolchain
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # Remove symlink that conflicts with COPY from toolchain
 RUN rm -rf /usr/local/man

--- a/Dockerfile.cross-musl-aarch64
+++ b/Dockerfile.cross-musl-aarch64
@@ -1,6 +1,6 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-musl:0.2.5 AS toolchain
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # Remove symlink that conflicts with COPY from toolchain
 RUN rm -rf /usr/local/man


### PR DESCRIPTION
# Description

Ubuntu 20.04 (focal) reached end-of-standard-support in April 2025. Its archive mirrors are being retired and are now intermittently unreachable, so apt-get update fails to fetch the package indexes and every subsequent apt-get install reports "no installation candidate."

Bump the base image from ubuntu:20.04 → ubuntu:22.04 in:

- Dockerfile.cross-gnu
- Dockerfile.cross-gnu-aarch64
- Dockerfile.cross-musl-aarch64
(Dockerfile.cross-musl was already on the Debian-based cross-rs musl image and is unaffected.)

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now.

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
