### PR TITLE
Add identity provider plugin support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,9 +238,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -248,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -425,6 +425,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +520,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,21 +575,15 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -1013,9 +1025,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dateparser"
@@ -1134,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
@@ -1157,11 +1169,11 @@ dependencies = [
 
 [[package]]
 name = "docker_credential"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+checksum = "a4564c274ebf369f501de192b02a0b81a5c4bda375abfe526aa70fc702fa6fa0"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "serde",
  "serde_json",
 ]
@@ -1189,9 +1201,7 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "drasi-bootstrap-application"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05bad8bc89e79ac8121037b86b78787fb41546dd195543aa3d70506ba92e9f1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1203,7 +1213,7 @@ dependencies = [
  "ordered-float",
  "postgres-types",
  "prost-types",
- "redis 0.25.4",
+ "redis 0.25.5",
  "serde",
  "serde_json",
  "tokio",
@@ -1215,9 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "drasi-bootstrap-noop"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea5ad96d7b3e69d6b9c467ce89bb863c9d7f6aa1eafe2d6ec07faef918f44a4"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1229,7 +1237,7 @@ dependencies = [
  "ordered-float",
  "postgres-types",
  "prost-types",
- "redis 0.25.4",
+ "redis 0.25.5",
  "serde",
  "serde_json",
  "tokio",
@@ -1241,14 +1249,13 @@ dependencies = [
 
 [[package]]
 name = "drasi-core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d680cd05ff03194bd7a23e244a42f1fd37a390facefc9d7bf58f3c6365be286"
+version = "0.5.0"
 dependencies = [
  "approx",
  "async-recursion",
  "async-stream",
  "async-trait",
+ "bytes",
  "caches",
  "chrono",
  "chrono-tz",
@@ -1282,33 +1289,25 @@ dependencies = [
 
 [[package]]
 name = "drasi-ffi-primitives"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148d5a99c8aae31e0f9c171f276822e42b9b1a2b6e19d759af1fbfeb743c21e6"
+version = "0.8.0"
 
 [[package]]
 name = "drasi-functions-cypher"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1741349a79439b7e798dcb2b273b9a9c0d71080522109e71d50bc722a8ea15b6"
+version = "0.5.0"
 dependencies = [
  "drasi-core",
 ]
 
 [[package]]
 name = "drasi-functions-gql"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19be32c6c8b22dd968abeeeeec0a61db7883bca803cd379c7d3094cefed2271"
+version = "0.5.0"
 dependencies = [
  "drasi-core",
 ]
 
 [[package]]
 name = "drasi-host-sdk"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6c98786cfdb0a0594d1e5a4a396efde3534318ca347a0f9291724e58794adf9"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1340,13 +1339,12 @@ dependencies = [
 
 [[package]]
 name = "drasi-index-garnet"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87c2058d1e932257b30a75770c300dc8fdbee96f9b61f660fd3d07dca50c808"
+version = "0.3.0"
 dependencies = [
  "async-recursion",
  "async-trait",
  "bit-set 0.5.3",
+ "bytes",
  "drasi-core",
  "drasi-query-ast",
  "fnv",
@@ -1355,7 +1353,7 @@ dependencies = [
  "log",
  "ordered-float",
  "prost",
- "redis 0.25.4",
+ "redis 0.25.5",
  "serde",
  "serde_json",
  "siphasher 0.3.11",
@@ -1365,13 +1363,12 @@ dependencies = [
 
 [[package]]
 name = "drasi-index-rocksdb"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa82b4c36fe63d5d90e92bd178d717f313f6ab2ec4178a6cde03e9f77d84961"
+version = "0.5.0"
 dependencies = [
  "async-stream",
  "async-trait",
  "bit-set 0.5.3",
+ "bytes",
  "drasi-core",
  "drasi-query-ast",
  "fastmurmur3",
@@ -1390,12 +1387,11 @@ dependencies = [
 
 [[package]]
 name = "drasi-lib"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b2173e4b9ee2749515069873d0c95018bc18b3f0567482d9bcc17096d05d5a"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bytes",
  "chrono",
  "drasi-core",
  "drasi-functions-cypher",
@@ -1406,6 +1402,7 @@ dependencies = [
  "drasi-query-gql",
  "fnv",
  "futures",
+ "im",
  "log",
  "ordered-float",
  "petgraph",
@@ -1423,9 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "drasi-middleware"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f70063dbaf9a80ef2c76aa8c940cee7003fc3b1457c614a6f0766907ac115cb5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1442,12 +1437,11 @@ dependencies = [
 
 [[package]]
 name = "drasi-plugin-sdk"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b45a111102551a28d6cdd6aee2322f10d2bf6bc91d263bc654b02afe92c981"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bytes",
  "chrono",
  "drasi-core",
  "drasi-ffi-primitives",
@@ -1465,9 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "drasi-query-ast"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67735fb6769ce9db6133dd63243afc6d59cee98db286fa562f1756d747204536"
+version = "0.3.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1476,9 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "drasi-query-cypher"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaac2a525e7362ccad675a5c37bd6ecf9e879a487174629b44de895764a5ca6b"
+version = "0.3.4"
 dependencies = [
  "drasi-query-ast",
  "peg",
@@ -1488,9 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "drasi-query-gql"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38efd2483c6e9faadaa1dcae5248d9f1a7dec22d3c73cec1fad9c9155684371"
+version = "0.3.4"
 dependencies = [
  "drasi-query-ast",
  "peg",
@@ -1500,9 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "drasi-reaction-application"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7f9bdc97d93279ab25a7a62944985a25450c786e318a96740b21063920bb4d7"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1558,7 +1544,7 @@ dependencies = [
  "oci-client",
  "openssl",
  "pretty_assertions",
- "redis 0.24.0",
+ "redis 0.24.1",
  "regex",
  "reqwest 0.12.28",
  "rstest",
@@ -1591,9 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "drasi-state-store-redb"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1342ac9ef8f7fe1f43ad07ed4a4d4eaaefb69af2c721fc1ba3b04164901e140e"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "drasi-lib",
@@ -1763,13 +1747,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -2127,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2177,9 +2160,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashers"
@@ -2232,7 +2215,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2349,9 +2332,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -2390,7 +2373,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2 0.4.14",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -2619,12 +2602,26 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+dependencies = [
+ "bitmaps",
+ "rand_core 0.6.4",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -2645,7 +2642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2722,16 +2719,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2772,27 +2759,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2844,9 +2836,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2896,9 +2888,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64 0.22.1",
  "getrandom 0.2.17",
@@ -2906,6 +2898,7 @@ dependencies = [
  "serde",
  "serde_json",
  "signature",
+ "zeroize",
 ]
 
 [[package]]
@@ -2935,11 +2928,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "285efcf12ef41bec907b3000d5ffaeb54191d4d9d83c0d6157e6cbc2db255e64"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
  "libc",
 ]
 
@@ -2983,10 +2976,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.1",
  "libc",
- "plain",
- "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -3087,7 +3077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3450,7 +3440,7 @@ dependencies = [
  "oci-spec",
  "olpc-cjson",
  "regex",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -3511,15 +3501,14 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3552,9 +3541,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -3709,9 +3698,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "peg"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9928cfca101b36ec5163e70049ee5368a8a1c3c6efc9ca9c5f9cc2f816152477"
+checksum = "0aad070be5b63aa72103f2fcdd70a83adbd5e90112ce5b574171ff1c65501773"
 dependencies = [
  "peg-macros",
  "peg-runtime",
@@ -3719,9 +3708,9 @@ dependencies = [
 
 [[package]]
 name = "peg-macros"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6298ab04c202fa5b5d52ba03269fb7b74550b150323038878fe6c372d8280f71"
+checksum = "ddd8ef6825cae95355031ae26a99b616a2a21f22ba2de0197c43dfb05acbe7ee"
 dependencies = [
  "peg-runtime",
  "proc-macro2",
@@ -3730,9 +3719,9 @@ dependencies = [
 
 [[package]]
 name = "peg-runtime"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dca9b868d927b35b5dd728167b2dee150eb1ad686008fc71ccb298b776fca"
+checksum = "7011d97b484a5ebdc4b1fdb3b12d5e4bbbea56e9d22b688f2e79e04b65a7d8a6"
 
 [[package]]
 name = "pem"
@@ -3837,7 +3826,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
- "siphasher 1.0.2",
+ "siphasher 1.0.3",
 ]
 
 [[package]]
@@ -3846,23 +3835,23 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
- "siphasher 1.0.2",
+ "siphasher 1.0.3",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3890,12 +3879,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -4415,6 +4398,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4434,9 +4426,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c580d9cbbe1d1b479e8d67cf9daf6a62c957e6846048408b80b43ac3f6af84cd"
+checksum = "9e23805debcc4435229c51187c0023a4d04499d354c101490e60744c087e973a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4455,9 +4447,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.25.4"
+version = "0.25.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d7a6955c7511f60f3ba9e86c6d02b3c3f144f8c24b288d1f4e18074ab8bbec"
+checksum = "5e46922bd01fefcfdcf58d9cd626da082bb2cde27211920dacfde6b2ecf9a35b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4488,15 +4480,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -4581,7 +4564,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
+ "h2 0.4.14",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -4603,7 +4586,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tower 0.5.3",
- "tower-http 0.6.8",
+ "tower-http 0.6.10",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4613,9 +4596,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4643,7 +4626,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
- "tower-http 0.6.8",
+ "tower-http 0.6.10",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4806,9 +4789,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4843,9 +4826,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4853,9 +4836,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -5107,11 +5090,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5126,9 +5110,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -5200,7 +5184,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5266,6 +5250,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5273,9 +5273,19 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
 
 [[package]]
 name = "slab"
@@ -5685,9 +5695,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -5907,20 +5917,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "iri-string",
  "pin-project-lite",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -6315,9 +6325,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6328,9 +6338,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6338,9 +6348,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6348,9 +6358,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6361,9 +6371,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -6417,9 +6427,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6455,9 +6465,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 dependencies = [
  "libc",
  "libredox",
@@ -6569,15 +6579,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -6619,21 +6620,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6686,12 +6672,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -6710,12 +6690,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -6731,12 +6705,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6770,12 +6738,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -6791,12 +6753,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6818,12 +6774,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -6839,12 +6789,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7096,9 +7040,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -7120,6 +7064,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Drasi core library (all middleware, using system libjq instead of bundled-jq)
-drasi-lib = { version = "0.6.0", features = [
+drasi-lib = { version = "0.8.0", features = [
   "middleware-jq",
   "middleware-decoder",
   "middleware-map",
@@ -47,27 +47,27 @@ drasi-lib = { version = "0.6.0", features = [
 ] }
 
 # Core models (for SourceMiddlewareConfig and other shared types)
-drasi-core = "0.4.2"
+drasi-core = "0.5.0"
 
 # Core bootstrap providers (used by the application API)
-drasi-bootstrap-noop = "0.1.12"
-drasi-bootstrap-application = "0.1.13"
+drasi-bootstrap-noop = "0.2.0"
+drasi-bootstrap-application = "0.2.0"
 
 # Core reaction (used by the application API)
-drasi-reaction-application = "0.2.11"
+drasi-reaction-application = "0.3.0"
 
 # Index plugins
-drasi-index-rocksdb = "0.3.2"
-drasi-index-garnet = "0.1.9"
+drasi-index-rocksdb = "0.5.0"
+drasi-index-garnet = "0.3.0"
 
 # State store plugins
-drasi-state-store-redb = "0.1.9"
+drasi-state-store-redb = "0.2.0"
 
 # Plugin SDK
-drasi-plugin-sdk = "0.6.0"
+drasi-plugin-sdk = "0.8.0"
 
 # Host SDK for dynamic plugin loading
-drasi-host-sdk = { version = "0.6.0", features = ["registry", "fetcher", "watcher"] }
+drasi-host-sdk = { version = "0.8.0", features = ["registry", "fetcher", "watcher"] }
 oci-client = "0.16"
 
 # Server-specific dependencies
@@ -121,7 +121,7 @@ futures = "0.3"
 tower = { version = "0.4", features = ["util"] }
 hyper = { version = "1.0", features = ["full"] }
 rstest = "0.18"
-drasi-core = "0.4.2"
+drasi-core = "0.5.0"
 
 # Integration testing with testcontainers
 testcontainers = "0.23"
@@ -152,14 +152,14 @@ large_enum_variant = "allow"
 
 
 # Local development: use path-based dependencies
-# [patch.crates-io]
-# drasi-core = { path = "../drasi-core/core" }
-# drasi-lib = { path = "../drasi-core/lib" }
-# drasi-bootstrap-noop = { path = "../drasi-core/components/bootstrappers/noop" }
-# drasi-bootstrap-application = { path = "../drasi-core/components/bootstrappers/application" }
-# drasi-reaction-application = { path = "../drasi-core/components/reactions/application" }
-# drasi-index-rocksdb = { path = "../drasi-core/components/indexes/rocksdb" }
-# drasi-index-garnet = { path = "../drasi-core/components/indexes/garnet" }
-# drasi-state-store-redb = { path = "../drasi-core/components/state_stores/redb" }
-# drasi-plugin-sdk = { path = "../drasi-core/components/plugin-sdk" }
-# drasi-host-sdk = { path = "../drasi-core/components/host-sdk" }
+[patch.crates-io]
+drasi-core = { path = "../drasi-core/core" }
+drasi-lib = { path = "../drasi-core/lib" }
+drasi-bootstrap-noop = { path = "../drasi-core/components/bootstrappers/noop" }
+drasi-bootstrap-application = { path = "../drasi-core/components/bootstrappers/application" }
+drasi-reaction-application = { path = "../drasi-core/components/reactions/application" }
+drasi-index-rocksdb = { path = "../drasi-core/components/indexes/rocksdb" }
+drasi-index-garnet = { path = "../drasi-core/components/indexes/garnet" }
+drasi-state-store-redb = { path = "../drasi-core/components/state_stores/redb" }
+drasi-plugin-sdk = { path = "../drasi-core/components/plugin-sdk" }
+drasi-host-sdk = { path = "../drasi-core/components/host-sdk" }

--- a/src/api/mappings/queries/mod.rs
+++ b/src/api/mappings/queries/mod.rs
@@ -96,6 +96,8 @@ impl ConfigMapper<QueryConfigDto, QueryConfig> for QueryConfigMapper {
             dispatch_mode,
             storage_backend,
             recovery_policy: None,
+            outbox_capacity: 1000,
+            bootstrap_timeout_secs: 300,
         })
     }
 }

--- a/src/api/models/identity_provider.rs
+++ b/src/api/models/identity_provider.rs
@@ -1,0 +1,207 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Identity provider configuration DTO.
+
+use serde::de::{self, Deserializer, MapAccess, Visitor};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Built-in identity provider kind that does not require a plugin.
+///
+/// The `password` identity provider is implemented directly in
+/// `drasi_lib::identity::PasswordIdentityProvider` and never goes through the
+/// plugin registry. All other kinds must be provided by an `identity/*` plugin.
+pub const BUILTIN_PASSWORD_KIND: &str = "password";
+
+/// Identity provider configuration with kind discriminator.
+///
+/// Mirrors the shape of [`SourceConfig`](super::source::SourceConfig) and
+/// [`ReactionConfig`](super::reaction::ReactionConfig): the deserializer
+/// pulls the common `kind` and `id` fields out of the YAML/JSON map and
+/// retains the remaining fields as a `serde_json::Value` to be forwarded
+/// to the plugin's `create_identity_provider` factory.
+///
+/// # Example YAML
+///
+/// ```yaml
+/// identityProviders:
+///   - kind: azure
+///     id: azure-developer
+///     identityName: "user@example.com"
+///     authMethod: developer_tools
+///
+///   - kind: password
+///     id: pg-password
+///     username: drasi
+///     password: ${PG_PASSWORD}
+/// ```
+#[derive(Debug, Clone)]
+pub struct IdentityProviderConfig {
+    pub kind: String,
+    pub id: String,
+    pub config: serde_json::Value,
+}
+
+impl IdentityProviderConfig {
+    /// Get the identity provider ID.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Get the identity provider kind (e.g. `azure`, `password`).
+    pub fn kind(&self) -> &str {
+        &self.kind
+    }
+
+    /// Returns `true` when this kind is built-in to drasi-lib and does not
+    /// require a registered identity provider plugin.
+    pub fn is_builtin(&self) -> bool {
+        self.kind == BUILTIN_PASSWORD_KIND
+    }
+}
+
+impl Serialize for IdentityProviderConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("kind", &self.kind)?;
+        map.serialize_entry("id", &self.id)?;
+        if let serde_json::Value::Object(config_map) = &self.config {
+            for (k, v) in config_map {
+                map.serialize_entry(k, v)?;
+            }
+        }
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for IdentityProviderConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct IdentityProviderConfigVisitor;
+
+        impl<'de> Visitor<'de> for IdentityProviderConfigVisitor {
+            type Value = IdentityProviderConfig;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter
+                    .write_str("an identity provider configuration with 'kind' and 'id' fields")
+            }
+
+            fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                let mut kind: Option<String> = None;
+                let mut id: Option<String> = None;
+                let mut remaining = serde_json::Map::new();
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "kind" => {
+                            if kind.is_some() {
+                                return Err(de::Error::duplicate_field("kind"));
+                            }
+                            kind = Some(map.next_value()?);
+                        }
+                        "id" => {
+                            if id.is_some() {
+                                return Err(de::Error::duplicate_field("id"));
+                            }
+                            id = Some(map.next_value()?);
+                        }
+                        other => {
+                            let value: serde_json::Value = map.next_value()?;
+                            remaining.insert(other.to_string(), value);
+                        }
+                    }
+                }
+
+                let kind = kind.ok_or_else(|| de::Error::missing_field("kind"))?;
+                let id = id.ok_or_else(|| de::Error::missing_field("id"))?;
+
+                Ok(IdentityProviderConfig {
+                    kind,
+                    id,
+                    config: serde_json::Value::Object(remaining),
+                })
+            }
+        }
+
+        deserializer.deserialize_map(IdentityProviderConfigVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_azure() {
+        let yaml = r#"
+            kind: azure
+            id: azure-dev
+            identityName: "user@example.com"
+            authMethod: developer_tools
+        "#;
+        let cfg: IdentityProviderConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.kind(), "azure");
+        assert_eq!(cfg.id(), "azure-dev");
+        assert!(!cfg.is_builtin());
+        assert_eq!(
+            cfg.config.get("identityName").and_then(|v| v.as_str()),
+            Some("user@example.com")
+        );
+        assert_eq!(
+            cfg.config.get("authMethod").and_then(|v| v.as_str()),
+            Some("developer_tools")
+        );
+    }
+
+    #[test]
+    fn deserialize_password_is_builtin() {
+        let yaml = r#"
+            kind: password
+            id: pg
+            username: drasi
+            password: secret
+        "#;
+        let cfg: IdentityProviderConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(cfg.is_builtin());
+        assert_eq!(
+            cfg.config.get("username").and_then(|v| v.as_str()),
+            Some("drasi")
+        );
+    }
+
+    #[test]
+    fn missing_id_errors() {
+        let yaml = "kind: azure\n";
+        let err = serde_yaml::from_str::<IdentityProviderConfig>(yaml).unwrap_err();
+        assert!(err.to_string().contains("id"));
+    }
+
+    #[test]
+    fn missing_kind_errors() {
+        let yaml = "id: x\n";
+        let err = serde_yaml::from_str::<IdentityProviderConfig>(yaml).unwrap_err();
+        assert!(err.to_string().contains("kind"));
+    }
+}

--- a/src/api/models/mod.rs
+++ b/src/api/models/mod.rs
@@ -36,6 +36,7 @@
 pub mod bootstrap;
 
 // Organized submodules
+pub mod identity_provider;
 pub mod observability;
 pub mod queries;
 pub mod reaction;
@@ -46,6 +47,7 @@ pub mod state_store;
 // Re-export all DTO types for convenient access
 pub use bootstrap::BootstrapProviderConfig;
 pub use drasi_plugin_sdk::config_value::*;
+pub use identity_provider::{IdentityProviderConfig, BUILTIN_PASSWORD_KIND};
 pub use observability::*;
 pub use queries::*;
 pub use reaction::ReactionConfig;

--- a/src/api/models/reaction.rs
+++ b/src/api/models/reaction.rs
@@ -29,6 +29,11 @@ pub struct ReactionConfig {
     pub id: String,
     pub queries: Vec<String>,
     pub auto_start: bool,
+    /// Reference (by `id`) to an entry in the top-level
+    /// `identityProviders` block. When set, the resolved provider is
+    /// attached to the reaction via `Reaction::set_identity_provider` after
+    /// construction.
+    pub identity_provider: Option<String>,
     pub config: serde_json::Value,
 }
 
@@ -43,6 +48,9 @@ impl Serialize for ReactionConfig {
         map.serialize_entry("id", &self.id)?;
         map.serialize_entry("queries", &self.queries)?;
         map.serialize_entry("autoStart", &self.auto_start)?;
+        if let Some(ip) = &self.identity_provider {
+            map.serialize_entry("identityProvider", ip)?;
+        }
         if let serde_json::Value::Object(config_map) = &self.config {
             for (k, v) in config_map {
                 map.serialize_entry(k, v)?;
@@ -71,11 +79,11 @@ impl<'de> Deserialize<'de> for ReactionConfig {
             where
                 M: MapAccess<'de>,
             {
-                // Storage for common fields
                 let mut kind: Option<String> = None;
                 let mut id: Option<String> = None;
                 let mut queries: Option<Vec<String>> = None;
                 let mut auto_start: Option<bool> = None;
+                let mut identity_provider: Option<String> = None;
 
                 // Collect remaining fields for the inner config
                 let mut remaining = serde_json::Map::new();
@@ -106,10 +114,21 @@ impl<'de> Deserialize<'de> for ReactionConfig {
                             }
                             auto_start = Some(map.next_value()?);
                         }
+                        "identityProvider" => {
+                            if identity_provider.is_some() {
+                                return Err(de::Error::duplicate_field("identityProvider"));
+                            }
+                            identity_provider = Some(map.next_value()?);
+                        }
                         // Reject common snake_case misspellings of known fields
                         "auto_start" => {
                             return Err(de::Error::custom(
                                 "unknown field `auto_start`, did you mean `autoStart`?",
+                            ));
+                        }
+                        "identity_provider" => {
+                            return Err(de::Error::custom(
+                                "unknown field `identity_provider`, did you mean `identityProvider`?",
                             ));
                         }
                         // Collect all other fields for the inner config
@@ -133,6 +152,7 @@ impl<'de> Deserialize<'de> for ReactionConfig {
                     id,
                     queries,
                     auto_start,
+                    identity_provider,
                     config: remaining_value,
                 })
             }
@@ -156,6 +176,12 @@ impl ReactionConfig {
     /// Check if auto_start is enabled
     pub fn auto_start(&self) -> bool {
         self.auto_start
+    }
+
+    /// Get the optional identity provider reference (id of an entry in
+    /// the top-level `identityProviders` block).
+    pub fn identity_provider(&self) -> Option<&str> {
+        self.identity_provider.as_deref()
     }
 
     /// Get the reaction kind
@@ -515,6 +541,7 @@ autoStart: true
             id: "roundtrip-reaction".to_string(),
             queries: vec!["q1".to_string(), "q2".to_string()],
             auto_start: false,
+            identity_provider: None,
             config: serde_json::json!({"routes": {}}),
         };
 

--- a/src/api/models/source.rs
+++ b/src/api/models/source.rs
@@ -48,6 +48,11 @@ pub struct SourceConfig {
     pub id: String,
     pub auto_start: bool,
     pub bootstrap_provider: Option<BootstrapProviderConfig>,
+    /// Reference (by `id`) to an entry in the top-level
+    /// `identityProviders` block. When set, the resolved provider is
+    /// attached to the source via `Source::set_identity_provider` after
+    /// construction.
+    pub identity_provider: Option<String>,
     pub config: serde_json::Value,
 }
 
@@ -63,6 +68,9 @@ impl Serialize for SourceConfig {
         map.serialize_entry("autoStart", &self.auto_start)?;
         if let Some(bp) = &self.bootstrap_provider {
             map.serialize_entry("bootstrapProvider", bp)?;
+        }
+        if let Some(ip) = &self.identity_provider {
+            map.serialize_entry("identityProvider", ip)?;
         }
         if let serde_json::Value::Object(config_map) = &self.config {
             for (k, v) in config_map {
@@ -96,6 +104,7 @@ impl<'de> Deserialize<'de> for SourceConfig {
                 let mut id: Option<String> = None;
                 let mut auto_start: Option<bool> = None;
                 let mut bootstrap_provider: Option<serde_json::Value> = None;
+                let mut identity_provider: Option<String> = None;
 
                 // Collect remaining fields for the inner config
                 let mut remaining = serde_json::Map::new();
@@ -126,6 +135,12 @@ impl<'de> Deserialize<'de> for SourceConfig {
                             }
                             bootstrap_provider = Some(map.next_value()?);
                         }
+                        "identityProvider" => {
+                            if identity_provider.is_some() {
+                                return Err(de::Error::duplicate_field("identityProvider"));
+                            }
+                            identity_provider = Some(map.next_value()?);
+                        }
                         // Reject common snake_case misspellings of known fields
                         "auto_start" => {
                             return Err(de::Error::custom(
@@ -135,6 +150,11 @@ impl<'de> Deserialize<'de> for SourceConfig {
                         "bootstrap_provider" => {
                             return Err(de::Error::custom(
                                 "unknown field `bootstrap_provider`, did you mean `bootstrapProvider`?"
+                            ));
+                        }
+                        "identity_provider" => {
+                            return Err(de::Error::custom(
+                                "unknown field `identity_provider`, did you mean `identityProvider`?"
                             ));
                         }
                         // Collect all other fields for the inner config
@@ -168,6 +188,7 @@ impl<'de> Deserialize<'de> for SourceConfig {
                     id,
                     auto_start,
                     bootstrap_provider,
+                    identity_provider,
                     config: remaining_value,
                 })
             }
@@ -196,6 +217,12 @@ impl SourceConfig {
     /// Get the bootstrap provider configuration if any
     pub fn bootstrap_provider(&self) -> Option<&BootstrapProviderConfig> {
         self.bootstrap_provider.as_ref()
+    }
+
+    /// Get the optional identity provider reference (id of an entry in
+    /// the top-level `identityProviders` block).
+    pub fn identity_provider(&self) -> Option<&str> {
+        self.identity_provider.as_deref()
     }
 
     /// Get the source kind
@@ -610,6 +637,7 @@ intervalMs: 1000
             id: "roundtrip-source".to_string(),
             auto_start: false,
             bootstrap_provider: None,
+            identity_provider: None,
             config: serde_json::json!({
                 "dataType": { "type": "sensorReading", "sensorCount": 5 },
                 "intervalMs": 1000

--- a/src/api/shared/handlers/instance_handlers.rs
+++ b/src/api/shared/handlers/instance_handlers.rs
@@ -259,6 +259,7 @@ pub async fn clone_instance(
             id: src_snap.id.clone(),
             auto_start: false,
             bootstrap_provider,
+            identity_provider: None,
             config: properties_json,
         };
 
@@ -335,6 +336,7 @@ pub async fn clone_instance(
             id: rx_snap.id.clone(),
             queries: rx_snap.queries.clone(),
             auto_start: false,
+            identity_provider: None,
             config: properties_json,
         };
 

--- a/src/api/shared/handlers/instance_handlers.rs
+++ b/src/api/shared/handlers/instance_handlers.rs
@@ -146,6 +146,7 @@ pub async fn create_instance(
             sources: Vec::new(),
             reactions: Vec::new(),
             queries: Vec::new(),
+            identity_providers: Vec::new(),
         };
         persistence.register_instance(instance_config).await;
         persist_after_operation(&Some(persistence.clone()), "creating instance").await?;

--- a/src/api/shared/solutions.rs
+++ b/src/api/shared/solutions.rs
@@ -338,6 +338,7 @@ pub async fn create_solution_template(
                 id: source_snap.id.clone(),
                 auto_start: source_snap.auto_start,
                 bootstrap_provider,
+                identity_provider: None,
                 config: properties_json,
             };
 
@@ -386,6 +387,7 @@ pub async fn create_solution_template(
                 id: reaction_snap.id.clone(),
                 queries: reaction_snap.queries.clone(),
                 auto_start: reaction_snap.auto_start,
+                identity_provider: None,
                 config: properties_json,
             };
 

--- a/src/config/plugin_validation.rs
+++ b/src/config/plugin_validation.rs
@@ -544,6 +544,7 @@ mod tests {
             id: id.to_string(),
             auto_start: true,
             bootstrap_provider: None,
+            identity_provider: None,
             config: serde_json::json!({}),
         }
     }
@@ -555,6 +556,7 @@ mod tests {
             auto_start: true,
             bootstrap_provider: Some(BootstrapProviderConfig {
                 kind: bp_kind.to_string(),
+                identity_provider: None,
                 config: serde_json::json!({}),
             }),
             config: serde_json::json!({}),
@@ -567,6 +569,7 @@ mod tests {
             id: id.to_string(),
             queries: vec![],
             auto_start: true,
+            identity_provider: None,
             config: serde_json::json!({}),
         }
     }
@@ -738,6 +741,7 @@ mod tests {
                 id: "s1".to_string(),
                 auto_start: true,
                 bootstrap_provider: None,
+                identity_provider: None,
                 config: serde_json::json!({"host": "localhost"}),
             }],
             vec![],
@@ -760,6 +764,7 @@ mod tests {
                 id: "s1".to_string(),
                 auto_start: true,
                 bootstrap_provider: None,
+                identity_provider: None,
                 config: serde_json::json!({
                     "host": {
                         "kind": "EnvironmentVariable",
@@ -789,6 +794,7 @@ mod tests {
                 id: "s1".to_string(),
                 auto_start: true,
                 bootstrap_provider: None,
+                identity_provider: None,
                 config: serde_json::json!({
                     "password": {
                         "kind": "EnvironmentVariable",
@@ -815,6 +821,7 @@ mod tests {
                 id: "s1".to_string(),
                 auto_start: true,
                 bootstrap_provider: None,
+                identity_provider: None,
                 config: serde_json::json!({
                     "host": {
                         "kind": "EnvironmentVariable",
@@ -840,6 +847,7 @@ mod tests {
                 id: "s1".to_string(),
                 auto_start: true,
                 bootstrap_provider: None,
+                identity_provider: None,
                 config: serde_json::json!({
                     "password": "${DRASI_TEST_HBS_MISSING}"
                 }),
@@ -862,6 +870,7 @@ mod tests {
                 id: "s1".to_string(),
                 auto_start: true,
                 bootstrap_provider: None,
+                identity_provider: None,
                 config: serde_json::json!({
                     "password": "${DRASI_TEST_HBS_DEFAULT:-secret}"
                 }),

--- a/src/config/schema_validation.rs
+++ b/src/config/schema_validation.rs
@@ -360,6 +360,7 @@ mod tests {
             id: id.to_string(),
             auto_start: true,
             bootstrap_provider: None,
+            identity_provider: None,
             config: serde_json::json!({}),
         }
     }
@@ -437,6 +438,7 @@ mod tests {
                 id: "pg1".to_string(),
                 auto_start: true,
                 bootstrap_provider: None,
+                identity_provider: None,
                 config: serde_json::json!({
                     "host": "localhost",
                     "database": "mydb"
@@ -458,6 +460,7 @@ mod tests {
                 id: "pg1".to_string(),
                 auto_start: true,
                 bootstrap_provider: None,
+                identity_provider: None,
                 config: serde_json::json!({
                     "host": "localhost"
                     // missing "database" which is required
@@ -485,6 +488,7 @@ mod tests {
                 id: "pg1".to_string(),
                 auto_start: true,
                 bootstrap_provider: None,
+                identity_provider: None,
                 config: serde_json::json!({
                     "host": "localhost",
                     "database": "mydb",
@@ -508,6 +512,7 @@ mod tests {
                 id: "pg1".to_string(),
                 auto_start: true,
                 bootstrap_provider: None,
+                identity_provider: None,
                 config: serde_json::json!({
                     "host": 12345,  // should be string
                     "database": "mydb"
@@ -530,6 +535,7 @@ mod tests {
                 id: "pg1".to_string(),
                 auto_start: true,
                 bootstrap_provider: None,
+                identity_provider: None,
                 config: serde_json::json!({
                     "host": "localhost",
                     "database": "mydb",
@@ -567,6 +573,7 @@ mod tests {
                 id: "log1".to_string(),
                 queries: vec![],
                 auto_start: true,
+                identity_provider: None,
                 config: serde_json::json!({
                     "level": "info"
                 }),
@@ -587,6 +594,7 @@ mod tests {
                 id: "log1".to_string(),
                 queries: vec![],
                 auto_start: true,
+                identity_provider: None,
                 config: serde_json::json!({
                     "level": "verbose"  // not in enum
                 }),
@@ -608,6 +616,7 @@ mod tests {
                 auto_start: true,
                 bootstrap_provider: Some(BootstrapProviderConfig {
                     kind: "scriptfile".to_string(),
+                    identity_provider: None,
                     config: serde_json::json!({
                         "filePaths": ["/data/file1.jsonl"]
                     }),
@@ -634,6 +643,7 @@ mod tests {
                 auto_start: true,
                 bootstrap_provider: Some(BootstrapProviderConfig {
                     kind: "scriptfile".to_string(),
+                    identity_provider: None,
                     config: serde_json::json!({}), // missing filePaths
                 }),
                 config: serde_json::json!({

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -23,7 +23,8 @@ use std::str::FromStr;
 // Import the config enums from api::models
 use crate::api::mappings::{DtoMapper, QueryConfigMapper};
 use crate::api::models::{
-    ConfigValue, QueryConfigDto, ReactionConfig, SourceConfig, StateStoreConfig,
+    ConfigValue, IdentityProviderConfig, QueryConfigDto, ReactionConfig, SourceConfig,
+    StateStoreConfig,
 };
 use drasi_lib::config::QueryConfig;
 
@@ -131,6 +132,10 @@ pub struct DrasiServerConfig {
     #[serde(default)]
     #[schema(value_type = Vec<serde_json::Value>)]
     pub reactions: Vec<ReactionConfig>,
+    /// Identity provider configurations (referenced by sources/reactions via `identityProvider: <id>`)
+    #[serde(default)]
+    #[schema(value_type = Vec<serde_json::Value>)]
+    pub identity_providers: Vec<IdentityProviderConfig>,
     /// Optional list of DrasiLib instances when running in multi-tenant mode
     #[serde(default)]
     pub instances: Vec<DrasiLibInstanceConfig>,
@@ -162,6 +167,7 @@ impl Default for DrasiServerConfig {
             sources: Vec::new(),
             queries: Vec::new(),
             reactions: Vec::new(),
+            identity_providers: Vec::new(),
             instances: Vec::new(),
         }
     }
@@ -276,6 +282,10 @@ pub struct DrasiLibInstanceConfig {
     #[serde(default)]
     #[schema(value_type = Vec<serde_json::Value>)]
     pub reactions: Vec<ReactionConfig>,
+    /// Identity provider configurations referenced by sources/reactions via `identityProvider: <id>`.
+    #[serde(default)]
+    #[schema(value_type = Vec<serde_json::Value>)]
+    pub identity_providers: Vec<IdentityProviderConfig>,
 }
 
 /// Resolved instance settings with ConfigValue evaluated
@@ -289,6 +299,7 @@ pub struct ResolvedInstanceConfig {
     pub sources: Vec<SourceConfig>,
     pub queries: Vec<QueryConfig>,
     pub reactions: Vec<ReactionConfig>,
+    pub identity_providers: Vec<IdentityProviderConfig>,
 }
 
 /// Validate hostname format according to RFC 1123
@@ -341,6 +352,7 @@ impl DrasiServerConfig {
                 sources: self.sources.clone(),
                 queries: self.queries.clone(),
                 reactions: self.reactions.clone(),
+                identity_providers: self.identity_providers.clone(),
             }]
         } else {
             self.instances.clone()
@@ -389,6 +401,7 @@ impl DrasiServerConfig {
                 sources: instance.sources.clone(),
                 queries,
                 reactions: instance.reactions.clone(),
+                identity_providers: instance.identity_providers.clone(),
             });
         }
 

--- a/src/dynamic_loading.rs
+++ b/src/dynamic_loading.rs
@@ -26,7 +26,8 @@ use drasi_host_sdk::callbacks::{self, CallbackContext};
 use drasi_host_sdk::loader::{PluginLoader, PluginLoaderConfig};
 use drasi_host_sdk::plugin_types::{PluginCategory, PluginKindEntry};
 use drasi_plugin_sdk::{
-    BootstrapPluginDescriptor, ReactionPluginDescriptor, SourcePluginDescriptor,
+    BootstrapPluginDescriptor, IdentityProviderPluginDescriptor, ReactionPluginDescriptor,
+    SourcePluginDescriptor,
 };
 use log::{debug, info, warn};
 use std::path::{Path, PathBuf};
@@ -38,9 +39,11 @@ const PLUGIN_FILE_PATTERNS: &[&str] = &[
     "libdrasi_source_*",
     "libdrasi_reaction_*",
     "libdrasi_bootstrap_*",
+    "libdrasi_identity_*",
     "drasi_source_*",
     "drasi_reaction_*",
     "drasi_bootstrap_*",
+    "drasi_identity_*",
 ];
 
 /// Statistics from a cdylib plugin loading operation.
@@ -51,6 +54,7 @@ pub struct PluginLoadStats {
     pub source_descriptors: usize,
     pub reaction_descriptors: usize,
     pub bootstrap_descriptors: usize,
+    pub identity_provider_descriptors: usize,
     /// Per-plugin information for orchestrator registration.
     pub loaded_plugins: Vec<StartupPluginRecord>,
 }
@@ -202,6 +206,23 @@ pub fn load_plugins(
             stats.bootstrap_descriptors += 1;
         }
 
+        for proxy in std::mem::take(&mut plugin.identity_provider_plugins) {
+            let kind = proxy.kind().to_string();
+            if plugin_id_parts.is_empty() {
+                plugin_id_parts.push(format!("identity/{kind}"));
+            }
+            info!("  [cdylib] identity: {kind} ({meta})");
+            plugin_kinds.push(PluginKindEntry {
+                category: PluginCategory::IdentityProvider,
+                kind: kind.clone(),
+                config_version: proxy.config_version().to_string(),
+                config_schema_name: proxy.config_schema_name().to_string(),
+            });
+            registry
+                .register_identity_provider_with_metadata(Arc::new(proxy), &plugin_id_parts[0]);
+            stats.identity_provider_descriptors += 1;
+        }
+
         let derived_plugin_id = plugin_id_parts
             .into_iter()
             .next()
@@ -218,17 +239,20 @@ pub fn load_plugins(
         stats.plugins_loaded += 1;
     }
 
-    let total_descriptors =
-        stats.source_descriptors + stats.reaction_descriptors + stats.bootstrap_descriptors;
+    let total_descriptors = stats.source_descriptors
+        + stats.reaction_descriptors
+        + stats.bootstrap_descriptors
+        + stats.identity_provider_descriptors;
 
     if stats.plugins_loaded > 0 {
         info!(
-            "cdylib plugin loading complete: {} loaded, {} descriptors ({} sources, {} reactions, {} bootstraps)",
+            "cdylib plugin loading complete: {} loaded, {} descriptors ({} sources, {} reactions, {} bootstraps, {} identity providers)",
             stats.plugins_loaded,
             total_descriptors,
             stats.source_descriptors,
             stats.reaction_descriptors,
             stats.bootstrap_descriptors,
+            stats.identity_provider_descriptors,
         );
     } else {
         debug!("No cdylib plugins found in '{}'", dir.display());

--- a/src/factories.rs
+++ b/src/factories.rs
@@ -345,6 +345,7 @@ mod tests {
             id: "test".to_string(),
             auto_start: true,
             bootstrap_provider: None,
+            identity_provider: None,
             config: serde_json::json!({}),
         };
 
@@ -365,6 +366,7 @@ mod tests {
             id: "test".to_string(),
             queries: vec![],
             auto_start: true,
+            identity_provider: None,
             config: serde_json::json!({}),
         };
 

--- a/src/factories.rs
+++ b/src/factories.rs
@@ -17,7 +17,8 @@
 //! This module provides factory functions that use the PluginRegistry to look up
 //! descriptors and create instances from generic config structs.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use drasi_lib::identity::{IdentityProvider, PasswordIdentityProvider};
 use drasi_lib::state_store::StateStoreProvider;
 use drasi_lib::{Reaction, Source};
 use log::info;
@@ -25,7 +26,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::api::mappings::DtoMapper;
-use crate::api::models::BootstrapProviderConfig;
+use crate::api::models::{BootstrapProviderConfig, IdentityProviderConfig, BUILTIN_PASSWORD_KIND};
 use crate::config::{ReactionConfig, SourceConfig, StateStoreConfig};
 use crate::plugin_registry::PluginRegistry;
 
@@ -271,6 +272,128 @@ pub fn get_reaction_plugin_metadata(
         }
     }
     meta
+}
+
+/// Create a single identity provider instance from configuration.
+///
+/// For the built-in `password` kind, this constructs a
+/// `PasswordIdentityProvider` directly from drasi-lib without consulting the
+/// plugin registry. All other kinds are resolved via
+/// `PluginRegistry::get_identity_provider(kind)` and built through the
+/// plugin's `create_identity_provider` factory.
+pub async fn create_identity_provider(
+    registry: &PluginRegistry,
+    config: &IdentityProviderConfig,
+) -> Result<Arc<dyn IdentityProvider>> {
+    if config.kind == BUILTIN_PASSWORD_KIND {
+        let username = config
+            .config
+            .get("username")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "identity provider '{}': missing or non-string 'username'",
+                    config.id
+                )
+            })?;
+        let password = config
+            .config
+            .get("password")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "identity provider '{}': missing or non-string 'password'",
+                    config.id
+                )
+            })?;
+        return Ok(Arc::new(PasswordIdentityProvider::new(username, password)));
+    }
+
+    let descriptor = registry
+        .get_identity_provider(&config.kind)
+        .cloned()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Unknown identity provider kind: '{}'. Available: {:?}",
+                config.kind,
+                registry.identity_provider_kinds()
+            )
+        })?;
+
+    let provider = descriptor
+        .create_identity_provider(&config.config)
+        .await
+        .with_context(|| {
+            format!(
+                "Failed to create identity provider '{}' (kind '{}')",
+                config.id, config.kind,
+            )
+        })?;
+
+    Ok(Arc::from(provider))
+}
+
+/// Acquire the registry read lock and create a single identity provider.
+pub async fn create_identity_provider_locked(
+    registry: &tokio::sync::RwLock<PluginRegistry>,
+    config: &IdentityProviderConfig,
+) -> Result<Arc<dyn IdentityProvider>> {
+    if config.kind == BUILTIN_PASSWORD_KIND {
+        let reg = registry.read().await;
+        return create_identity_provider(&reg, config).await;
+    }
+
+    // For plugin-backed providers, clone the descriptor under the lock and
+    // drop the guard before awaiting plugin construction.
+    let descriptor = {
+        let reg = registry.read().await;
+        reg.get_identity_provider(&config.kind)
+            .cloned()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Unknown identity provider kind: '{}'. Available: {:?}",
+                    config.kind,
+                    reg.identity_provider_kinds()
+                )
+            })?
+    };
+
+    let provider = descriptor
+        .create_identity_provider(&config.config)
+        .await
+        .with_context(|| {
+            format!(
+                "Failed to create identity provider '{}' (kind '{}')",
+                config.id, config.kind,
+            )
+        })?;
+
+    Ok(Arc::from(provider))
+}
+
+/// Build a `{id -> provider}` map from a slice of identity-provider configs.
+///
+/// Fails on duplicate ids or if any plugin-backed kind is not registered.
+pub async fn build_identity_provider_map(
+    registry: &tokio::sync::RwLock<PluginRegistry>,
+    configs: &[IdentityProviderConfig],
+) -> Result<HashMap<String, Arc<dyn IdentityProvider>>> {
+    let mut map: HashMap<String, Arc<dyn IdentityProvider>> = HashMap::new();
+    for cfg in configs {
+        if map.contains_key(&cfg.id) {
+            return Err(anyhow::anyhow!(
+                "Duplicate identityProvider id '{}'",
+                cfg.id
+            ));
+        }
+        let provider = create_identity_provider_locked(registry, cfg).await?;
+        info!(
+            "Configured identity provider '{}' (kind '{}')",
+            cfg.id, cfg.kind
+        );
+        map.insert(cfg.id.clone(), provider);
+    }
+    Ok(map)
 }
 
 #[cfg(test)]

--- a/src/init/builder.rs
+++ b/src/init/builder.rs
@@ -87,6 +87,7 @@ pub fn build_config(
         sources,
         queries,
         reactions,
+        identity_providers: Vec::new(),
         instances: vec![], // Empty = use single-instance mode
     }
 }

--- a/src/init/builder.rs
+++ b/src/init/builder.rs
@@ -142,6 +142,7 @@ mod tests {
             id: id.to_string(),
             auto_start: true,
             bootstrap_provider: None,
+            identity_provider: None,
             config: json!({"dataType": {"type": "generic"}, "intervalMs": 5000}),
         }
     }
@@ -153,6 +154,7 @@ mod tests {
             id: id.to_string(),
             auto_start: true,
             bootstrap_provider: None,
+            identity_provider: None,
             config: json!({"host": "0.0.0.0", "port": 9000, "timeoutMs": 10000}),
         }
     }
@@ -164,6 +166,7 @@ mod tests {
             id: id.to_string(),
             queries: vec!["my-query".to_string()],
             auto_start: true,
+            identity_provider: None,
             config: json!({"routes": {}}),
         }
     }
@@ -175,6 +178,7 @@ mod tests {
             id: id.to_string(),
             queries: vec!["my-query".to_string()],
             auto_start: true,
+            identity_provider: None,
             config: json!({"host": "0.0.0.0", "port": 8081, "ssePath": "/events", "heartbeatIntervalMs": 30000, "routes": {}}),
         }
     }

--- a/src/init/prompts.rs
+++ b/src/init/prompts.rs
@@ -295,6 +295,7 @@ fn prompt_postgres_source() -> Result<SourceConfig> {
         id,
         auto_start: true,
         bootstrap_provider,
+        identity_provider: None,
         config: serde_json::json!({
             "host": host,
             "port": port,
@@ -433,6 +434,7 @@ fn prompt_http_source() -> Result<SourceConfig> {
         id,
         auto_start: true,
         bootstrap_provider,
+        identity_provider: None,
         config: serde_json::json!({
             "host": host,
             "port": port,
@@ -464,6 +466,7 @@ fn prompt_grpc_source() -> Result<SourceConfig> {
         id,
         auto_start: true,
         bootstrap_provider,
+        identity_provider: None,
         config: serde_json::json!({
             "host": host,
             "port": port,
@@ -509,6 +512,7 @@ fn prompt_mock_source() -> Result<SourceConfig> {
         id,
         auto_start: true,
         bootstrap_provider: None,
+        identity_provider: None,
         config: serde_json::json!({
             "intervalMs": interval_ms,
             "dataType": data_type
@@ -563,6 +567,7 @@ fn prompt_log_reaction() -> Result<ReactionConfig> {
         id,
         queries: vec!["my-query".to_string()],
         auto_start: true,
+        identity_provider: None,
         config: serde_json::json!({
             "routes": {}
         }),
@@ -588,6 +593,7 @@ fn prompt_http_reaction() -> Result<ReactionConfig> {
         id,
         queries: vec!["my-query".to_string()],
         auto_start: true,
+        identity_provider: None,
         config: serde_json::json!({
             "baseUrl": base_url,
             "timeoutMs": 5000,
@@ -620,6 +626,7 @@ fn prompt_sse_reaction() -> Result<ReactionConfig> {
         id,
         queries: vec!["my-query".to_string()],
         auto_start: true,
+        identity_provider: None,
         config: serde_json::json!({
             "host": host,
             "port": port,
@@ -649,6 +656,7 @@ fn prompt_grpc_reaction() -> Result<ReactionConfig> {
         id,
         queries: vec!["my-query".to_string()],
         auto_start: true,
+        identity_provider: None,
         config: serde_json::json!({
             "endpoint": endpoint,
             "timeoutMs": 5000,
@@ -832,6 +840,7 @@ fn prompt_generic_source(kind: &str) -> Result<SourceConfig> {
         kind: kind.to_string(),
         id,
         auto_start: true,
+        identity_provider: None,
         bootstrap_provider,
         config,
     })
@@ -931,6 +940,7 @@ fn prompt_generic_reaction(kind: &str) -> Result<ReactionConfig> {
         id,
         queries: vec!["my-query".to_string()],
         auto_start: true,
+        identity_provider: None,
         config,
     })
 }

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -167,6 +167,7 @@ impl ConfigPersistence {
                         kind: s.source_type.clone(),
                         id: s.id.clone(),
                         auto_start: s.auto_start,
+                        identity_provider: None,
                         bootstrap_provider: s.bootstrap_provider.as_ref().map(|bp| {
                             let mut bp_config = serde_json::Map::new();
                             for (k, v) in &bp.properties {
@@ -209,6 +210,7 @@ impl ConfigPersistence {
                         id: r.id.clone(),
                         queries: r.queries.clone(),
                         auto_start: r.auto_start,
+                        identity_provider: None,
                         config: serde_json::Value::Object(config_map),
                     }
                 })

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -231,6 +231,7 @@ impl ConfigPersistence {
                     sources,
                     reactions,
                     queries,
+                    identity_providers: Vec::new(),
                 }
             } else {
                 DrasiLibInstanceConfig {
@@ -242,6 +243,7 @@ impl ConfigPersistence {
                     sources,
                     reactions,
                     queries,
+                    identity_providers: Vec::new(),
                 }
             };
             instance_configs.push(instance_config);
@@ -275,6 +277,7 @@ impl ConfigPersistence {
                 sources: instance.sources,
                 queries: instance.queries,
                 reactions: instance.reactions,
+                identity_providers: Vec::new(),
                 instances: Vec::new(), // Empty = single-instance format
             }
         } else {
@@ -311,6 +314,7 @@ impl ConfigPersistence {
                 sources: Vec::new(),
                 queries: Vec::new(),
                 reactions: Vec::new(),
+                identity_providers: Vec::new(),
                 instances: instance_configs,
             }
         };

--- a/src/server.rs
+++ b/src/server.rs
@@ -27,7 +27,10 @@ use utoipa_swagger_ui::SwaggerUi;
 
 use crate::api;
 use crate::api::mappings::{map_server_settings, DtoMapper};
-use crate::factories::{create_reaction_locked, create_source_locked, create_state_store_provider};
+use crate::factories::{
+    build_identity_provider_map, create_reaction_locked, create_source_locked,
+    create_state_store_provider,
+};
 use crate::instance_registry::InstanceRegistry;
 use crate::load_config_file;
 use crate::persistence::ConfigPersistence;
@@ -422,6 +425,11 @@ impl DrasiServer {
                 builder = builder.with_state_store_provider(state_store_provider);
             }
 
+            // Build the identity-provider map for this instance. Sources and
+            // reactions can reference entries here via `identityProvider: <id>`.
+            let identity_providers =
+                build_identity_provider_map(&plugin_registry, &instance.identity_providers).await?;
+
             // Create and add sources from config
             info!(
                 "Loading {} source(s) from configuration for instance '{}'",
@@ -429,8 +437,19 @@ impl DrasiServer {
                 instance.id
             );
             for source_config in instance.sources.clone() {
+                let identity_ref = source_config.identity_provider().map(str::to_string);
                 let (source, plugin_meta) =
                     create_source_locked(&plugin_registry, source_config).await?;
+                if let Some(id) = identity_ref {
+                    let provider = identity_providers.get(&id).cloned().ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Source references unknown identityProvider '{id}'. \
+                             Declared providers: {:?}",
+                            identity_providers.keys().collect::<Vec<_>>()
+                        )
+                    })?;
+                    source.set_identity_provider(provider).await;
+                }
                 builder = builder.with_source_metadata(source, plugin_meta);
             }
 
@@ -441,8 +460,19 @@ impl DrasiServer {
 
             // Create and add reactions from config
             for reaction_config in instance.reactions.clone() {
+                let identity_ref = reaction_config.identity_provider().map(str::to_string);
                 let (reaction, plugin_meta) =
                     create_reaction_locked(&plugin_registry, reaction_config).await?;
+                if let Some(id) = identity_ref {
+                    let provider = identity_providers.get(&id).cloned().ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Reaction references unknown identityProvider '{id}'. \
+                             Declared providers: {:?}",
+                            identity_providers.keys().collect::<Vec<_>>()
+                        )
+                    })?;
+                    reaction.set_identity_provider(provider).await;
+                }
                 builder = builder.with_reaction_metadata(reaction, plugin_meta);
             }
 


### PR DESCRIPTION
# Description
## Summary

Wires up the new identity-provider plugin category end-to-end in `drasi-server`, so sources, reactions, and bootstrap providers can resolve credentials through a shared, named identity plugin instance instead of inlining secrets in every component config. This unblocks the dataverse source/bootstrapper, which require Azure credentials, and is the foundation for any future plugin that needs pluggable auth.

## What's changed

**Identity provider as a first-class component**
- New DTO and mappings: `src/api/models/identity_provider.rs`, registered in `api/models/mod.rs` and `api/mappings/queries/mod.rs`.
- Config schema and YAML parsing extended (`src/config/types.rs`, `schema_validation.rs`, `plugin_validation.rs`) to accept an `identityProviders:` section alongside `sources` / `queries` / `reactions`.
- Persistence updated (`src/persistence.rs`) to round-trip identity providers through snapshot save/load.

**Plumbing through the plugin runtime**
- `src/dynamic_loading.rs` recognises the new `identity-provider` plugin category when scanning cdylibs and reports them in the load summary.
- `src/factories.rs` resolves a component's `identityProvider` field to the corresponding loaded identity-provider plugin instance and passes it to source/reaction/bootstrap factories at construction time.
- `src/server.rs` includes identity providers in the plugin verification path, missing-plugin diagnostics, and the available-kinds error message.

**Component config surface**
- `sources` and `reactions` DTOs gained an optional `identityProvider` field (`src/api/models/source.rs`, `reaction.rs`) so YAML and the REST API can reference a named identity provider by id.
- Instance handlers and solutions surface the new field where relevant.

**Init wizard**
- `src/init/prompts.rs` and `init/builder.rs` ask about identity providers during interactive setup.

**UI cleanup**
- Removes a large pile of unused RJSF theme code (`rjsf-theme/`, `uiSchemaMapper.ts`, custom widgets/templates) and simplifies `ConfigEditor.tsx`, `SchemaConfigForm.tsx`, `SourceForms.tsx`, and `ReactionForms.tsx` to use the upstream theme directly. Net: ~700 lines removed from the UI.
- `src/ui_assets.rs` deleted in favour of the existing asset pipeline.

**Build/CI hygiene**
- `Dockerfile.cross-musl` and `.github/workflows/release.yaml` adjustments to keep cross builds green.
- `build.rs` simplified.
- `Cargo.lock` / `Cargo.toml` updates to pull in the matching `drasi-core` / `host-sdk` revisions that introduce the identity-provider plugin SDK.

## Example config

```yaml
apiVersion: drasi.io/v1

identityProviders:
  - id: azure-dev
    kind: identity-provider/azure
    # no client_secret → falls back to Azure CLI / DefaultAzureCredential

sources:
  - id: dataverse-src
    kind: source/dataverse
    identityProvider: azure-dev
    bootstrapProvider:
      kind: bootstrap/dataverse
      identityProvider: azure-dev
    properties:
      environmentUrl: https://contoso.crm.dynamics.com
```

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now.

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
