### PR TITLE
Fixes due to Getting Started doc revision

### DIFF
--- a/.devcontainer/getting-started/post-create.sh
+++ b/.devcontainer/getting-started/post-create.sh
@@ -5,10 +5,6 @@ set -e
 
 echo "🔧 Initializing Drasi Server Getting Started tutorial environment..."
 
-# Ensure the shared Docker network exists (for connecting to PostgreSQL container)
-echo "🌐 Creating shared Docker network..."
-docker network create drasi-network 2>/dev/null || true
-
 # Install system dependencies
 echo "🐘 Installing system dependencies (PostgreSQL client)..."
 sudo apt-get update && sudo apt-get install -y postgresql-client

--- a/examples/getting-started/configs/getting-started-step-3.yaml
+++ b/examples/getting-started/configs/getting-started-step-3.yaml
@@ -1,8 +1,6 @@
 # Drasi Server Configuration
-# Generated with: drasi-server init
 #
 # Edit this file to customize your configuration.
-# See documentation at: https://drasi.io/docs
 
 id: ccc77569-0c72-4865-ac2b-3cde1ef03d8d
 host: 0.0.0.0
@@ -58,8 +56,3 @@ reactions:
   autoStart: true
   routes: {}
 instances: []
-
-# Tips:
-# - Use environment variables: ${VAR_NAME:-default}
-# - Update 'my-query' with your actual GQL query
-# - Connect reactions to your queries by updating the 'queries' field

--- a/examples/getting-started/configs/getting-started-step-4.yaml
+++ b/examples/getting-started/configs/getting-started-step-4.yaml
@@ -1,37 +1,43 @@
+# Drasi Server Configuration
+#
+# Edit this file to customize your configuration.
+
 id: ccc77569-0c72-4865-ac2b-3cde1ef03d8d
 host: 0.0.0.0
 port: 8080
 logLevel: info
 persistConfig: true
 persistIndex: false
+enableUi: true
+pluginRegistry: ghcr.io/drasi-project
 autoInstallPlugins: true
 plugins:
 - ref: source/postgres
 - ref: bootstrap/postgres
 - ref: reaction/log
+verifyPlugins: true
+hotReloadPlugins: false
+hotReloadDebounceMs: 2000
 sources:
 - kind: postgres
   id: my-postgres
   autoStart: true
   bootstrapProvider:
     kind: postgres
-  host:
-    kind: EnvironmentVariable
-    name: DB_HOST
-    default: localhost
-  port: 5432
   database: getting_started
-  user: drasi_user
+  host: ${DB_HOST:-localhost}
   password: drasi_password
-  tables:
-  - Message
-  slotName: drasi_slot
+  port: 5432
   publicationName: drasi_pub
+  slotName: drasi_slot
   sslMode: prefer
   tableKeys:
-  - table: Message
-    keyColumns:
+  - keyColumns:
     - MessageId
+    table: Message
+  tables:
+  - Message
+  user: drasi_user
 queries:
 - id: all-messages
   autoStart: true
@@ -47,6 +53,10 @@ queries:
     pipeline: []
   enableBootstrap: true
   bootstrapBufferSize: 10000
+  priorityQueueCapacity: 10000
+  dispatchBufferCapacity: 1000
+  outboxCapacity: 1000
+  bootstrapTimeoutSecs: 300
 - id: hello-world-senders
   autoStart: true
   query: MATCH (m:Message) WHERE m.Message = 'Hello World' RETURN m.MessageId AS Id, m.From AS Sender
@@ -59,6 +69,8 @@ queries:
     pipeline: []
   enableBootstrap: true
   bootstrapBufferSize: 10000
+  outboxCapacity: 1000
+  bootstrapTimeoutSecs: 300
 reactions:
 - kind: log
   id: log-reaction
@@ -66,5 +78,5 @@ reactions:
   - all-messages
   - hello-world-senders
   autoStart: true
-  routes: {}
+identityProviders: []
 instances: []

--- a/examples/getting-started/configs/getting-started-step-5.yaml
+++ b/examples/getting-started/configs/getting-started-step-5.yaml
@@ -1,3 +1,7 @@
+# Drasi Server Configuration
+#
+# Edit this file to customize your configuration.
+
 id: ccc77569-0c72-4865-ac2b-3cde1ef03d8d
 host: 0.0.0.0
 port: 8080

--- a/examples/getting-started/configs/getting-started-step-6.yaml
+++ b/examples/getting-started/configs/getting-started-step-6.yaml
@@ -1,3 +1,7 @@
+# Drasi Server Configuration
+#
+# Edit this file to customize your configuration.
+
 id: ccc77569-0c72-4865-ac2b-3cde1ef03d8d
 host: 0.0.0.0
 port: 8080

--- a/examples/getting-started/database/docker-compose.yml
+++ b/examples/getting-started/database/docker-compose.yml
@@ -45,7 +45,6 @@ services:
 networks:
   drasi-network:
     name: drasi-network
-    external: true
 
 volumes:
   getting_started_postgres_data:

--- a/src/api/v1/mod.rs
+++ b/src/api/v1/mod.rs
@@ -58,5 +58,6 @@ pub use handlers::*;
 pub use openapi::inject_plugin_schemas;
 pub use openapi::ApiDocV1;
 pub use openapi::OpenApiCache;
+pub use plugin_handlers::build_plugin_router;
 pub use plugin_handlers::plugin_routes;
 pub use routes::build_v1_router;

--- a/src/api/v1/plugin_handlers.rs
+++ b/src/api/v1/plugin_handlers.rs
@@ -545,7 +545,14 @@ pub async fn search_registry(
     }
 }
 
-/// Build the plugin API router.
+/// Build the plugin API router (without extensions).
+///
+/// Prefer [`build_plugin_router`] which wires the required extensions in the
+/// same place as the routes. Callers using `plugin_routes()` directly must add
+/// every extension that any plugin handler extracts, including
+/// `Extension<Arc<PluginOrchestrator>>`, `Extension<InstanceRegistry>`, and
+/// `Extension<Arc<bool>>` (the read-only flag used by `load_plugin` /
+/// `install_plugin`).
 pub fn plugin_routes() -> axum::Router {
     // Schema subrouter — needs to be separate to avoid {plugin_id} conflict
     let kinds_router = axum::Router::new()
@@ -566,4 +573,21 @@ pub fn plugin_routes() -> axum::Router {
             "/:plugin_id/dependents",
             axum::routing::get(list_dependents),
         )
+}
+
+/// Build the plugin API router with all required extensions layered.
+///
+/// This is the preferred constructor: it collocates the route definitions
+/// with the extensions that the handlers extract so that adding a new
+/// extension to a handler is caught here rather than at request time with a
+/// `Missing request extension` error.
+pub fn build_plugin_router(
+    orchestrator: Arc<PluginOrchestrator>,
+    instances: InstanceRegistry,
+    read_only: Arc<bool>,
+) -> axum::Router {
+    plugin_routes()
+        .layer(Extension(orchestrator))
+        .layer(Extension(instances))
+        .layer(Extension(read_only))
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -828,9 +828,11 @@ impl DrasiServer {
         );
 
         // Build the plugin management sub-router
-        let plugin_router = api::v1::plugin_routes()
-            .layer(axum::extract::Extension(self.plugin_orchestrator.clone()))
-            .layer(axum::extract::Extension(registry.clone()));
+        let plugin_router = api::v1::build_plugin_router(
+            self.plugin_orchestrator.clone(),
+            registry.clone(),
+            self.read_only.clone(),
+        );
 
         // Build the main application router
         let mut app = Router::new()

--- a/tests/api_plugin_routing_test.rs
+++ b/tests/api_plugin_routing_test.rs
@@ -1,0 +1,211 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Plugin sub-router extension wiring regression tests.
+//!
+//! These tests exist to catch the class of bug where `/api/v1/plugins/*`
+//! routes are nested under the root app router separately from the rest of
+//! the v1 router and therefore do not inherit Axum `Extension` layers added
+//! to the v1 router. Without these tests, handlers like `install_plugin`
+//! and `load_plugin` (which extract `Extension<Arc<bool>>` for read-only
+//! enforcement) would fail at request time with:
+//!
+//!     Missing request extension: Extension of type `alloc::sync::Arc<bool>`
+//!     was not found.
+//!
+//! Any future handler added to `plugin_routes()` that extracts a new
+//! `Extension<T>` MUST also have `T` added in `build_plugin_router` —
+//! these tests will fail until that happens.
+
+#![allow(clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use axum::{
+    body::{to_bytes, Body},
+    http::{Request, StatusCode},
+    Router,
+};
+use drasi_host_sdk::lifecycle::PluginLifecycleManager;
+use drasi_host_sdk::plugin_registry::PluginRegistry;
+use drasi_server::api::v1::build_plugin_router;
+use drasi_server::instance_registry::InstanceRegistry;
+use drasi_server::plugin_orchestrator::PluginOrchestrator;
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+
+/// Build a router that mirrors the production wiring in `server.rs`:
+/// the plugin sub-router is nested separately under `/api/v1/plugins`,
+/// reproducing the conditions that caused the missing-extension bug.
+fn build_test_app(read_only: bool) -> Router {
+    let registry = Arc::new(RwLock::new(PluginRegistry::new()));
+    let lifecycle = Arc::new(PluginLifecycleManager::new(registry));
+    let orchestrator = Arc::new(PluginOrchestrator::new(lifecycle));
+    let instances = InstanceRegistry::new();
+
+    let plugin_router = build_plugin_router(orchestrator, instances, Arc::new(read_only));
+
+    Router::new().nest("/api/v1/plugins", plugin_router)
+}
+
+/// Regression test: `POST /api/v1/plugins/install` must not fail with the
+/// "Missing request extension" error introduced when the plugin sub-router
+/// was nested separately from the v1 router without re-adding the
+/// `Arc<bool>` (read-only) extension. When the server is in read-only mode
+/// the handler must return a structured `CONFIG_READ_ONLY` error.
+#[tokio::test]
+async fn install_plugin_returns_read_only_error_when_read_only() {
+    let app = build_test_app(true);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/plugins/install")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"ref":"reaction/sse"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+
+    assert!(
+        !body_str.contains("Missing request extension"),
+        "install endpoint is missing a required Extension layer: {body_str}"
+    );
+
+    // CONFIG_READ_ONLY maps to HTTP 409 CONFLICT per the error code table.
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "expected 409 CONFLICT (CONFIG_READ_ONLY), got {status} body={body_str}"
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["code"], "CONFIG_READ_ONLY", "body={body_str}");
+}
+
+/// Regression test: `POST /api/v1/plugins/install` must not fail with the
+/// "Missing request extension" error when read-only mode is disabled. The
+/// handler is expected to reach the orchestrator and fail with
+/// `PLUGIN_INSTALL_FAILED` (because the test orchestrator has no
+/// `PluginOperations` configured) — proving the extension is plumbed AND the
+/// handler actually executed.
+#[tokio::test]
+async fn install_plugin_reaches_handler_when_writable() {
+    let app = build_test_app(false);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/plugins/install")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"ref":"reaction/sse"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+
+    assert!(
+        !body_str.contains("Missing request extension"),
+        "install endpoint is missing a required Extension layer: {body_str}"
+    );
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_GATEWAY,
+        "expected 502 BAD_GATEWAY from orchestrator without PluginOperations, got {status} body={body_str}"
+    );
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["code"], "PLUGIN_INSTALL_FAILED", "body={body_str}");
+}
+
+/// Regression test: `POST /api/v1/plugins/load` is the second handler that
+/// extracts `Extension<Arc<bool>>` and would have hit the same missing-
+/// extension bug. Verify it also reaches the handler successfully.
+#[tokio::test]
+async fn load_plugin_returns_read_only_error_when_read_only() {
+    let app = build_test_app(true);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/plugins/load")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"filename":"libdrasi_reaction_sse.so"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+
+    assert!(
+        !body_str.contains("Missing request extension"),
+        "load endpoint is missing a required Extension layer: {body_str}"
+    );
+
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "expected 409 CONFLICT (CONFIG_READ_ONLY), got {status} body={body_str}"
+    );
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["code"], "CONFIG_READ_ONLY", "body={body_str}");
+}
+
+/// `GET /api/v1/plugins` must remain reachable through the plugin sub-router
+/// (this handler does not need `read_only`, but it relies on the orchestrator
+/// extension being present).
+#[tokio::test]
+async fn list_plugins_reaches_handler() {
+    let app = build_test_app(false);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/plugins")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+
+    assert!(
+        !body_str.contains("Missing request extension"),
+        "list endpoint is missing a required Extension layer: {body_str}"
+    );
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "expected 200 OK, got {status} body={body_str}"
+    );
+}


### PR DESCRIPTION
This pull request improves the reliability and maintainability of the Drasi Server's plugin API routing, particularly ensuring that required Axum extensions are always correctly wired for plugin management endpoints. It introduces a new, safer way to construct the plugin router, updates the server to use this method, and adds regression tests to prevent related bugs in the future. There are also minor documentation and configuration cleanups in the getting started examples.

**Plugin API Routing Reliability Improvements:**

* Added a new `build_plugin_router` function in `plugin_handlers.rs` that constructs the plugin API router with all required Axum `Extension` layers, ensuring handlers always receive the necessary dependencies. This replaces the previous pattern where extensions had to be added manually, which was error-prone.
* Updated the main server (`server.rs`) to use `build_plugin_router` instead of manually layering extensions, preventing missing-extension runtime errors for plugin endpoints.
* Re-exported `build_plugin_router` from the API module for use by the server.
* Improved documentation for `plugin_routes` and `build_plugin_router` to clarify their intended usage and extension requirements.

**Testing and Regression Prevention:**

* Added a comprehensive regression test suite (`api_plugin_routing_test.rs`) that verifies plugin endpoints (`/api/v1/plugins/install`, `/api/v1/plugins/load`, and `/api/v1/plugins`) always receive the necessary extensions and return the correct errors or results, catching future miswirings early.

**Getting Started and Example Configuration Cleanups:**

* Cleaned up comments and improved clarity in example YAML configurations for the getting started tutorial, including removing outdated tips, updating environment variable usage, and adding missing documentation headers. [[1]](diffhunk://#diff-6351576cf28c14f7f871319186e6cc56a22d4a1a9447b0aa7aa7d32c190fc894L2-L5) [[2]](diffhunk://#diff-6351576cf28c14f7f871319186e6cc56a22d4a1a9447b0aa7aa7d32c190fc894L61-L65) [[3]](diffhunk://#diff-76005af34fcbb84dd71a0bf4fc305c3f5297272e3319a11f64db14c99125c081R1-R40) [[4]](diffhunk://#diff-76005af34fcbb84dd71a0bf4fc305c3f5297272e3319a11f64db14c99125c081R56-R59) [[5]](diffhunk://#diff-76005af34fcbb84dd71a0bf4fc305c3f5297272e3319a11f64db14c99125c081R72-R81) [[6]](diffhunk://#diff-0d3420a0031ad49a2591acb6b8c6ee53a0b867b12bb1d2ff22474aa2f7486520R1-R4) [[7]](diffhunk://#diff-9c59f6942105f8a915d4608a95043d54ea82f4ac3aff49a318f178a04d503a65R1-R4)
* Removed unnecessary Docker network creation and external flag from devcontainer and Docker Compose files to simplify setup. [[1]](diffhunk://#diff-851a31bc0a4f1b694049ee37747a8a06ddb1f373450a14984fcadcdfe4a1408cL8-L11) [[2]](diffhunk://#diff-32806dfa911da0f2d081f70a23182c0b3d74b239a5377cc3777f2032a674d541L48)

These changes make the plugin API more robust against misconfiguration, easier to extend, and better tested.