### PR TITLE
fix(build): install rustls CryptoProvider before downloading vendored libs on Windows MSVC

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -148,6 +148,12 @@ fn download_vendor(target: &str, vendor_dir: &std::path::Path) -> Result<(), Str
     use sha2::{Digest, Sha256};
     use tar::Archive;
 
+    // ureq is built with `rustls-no-provider`, so we must install a default
+    // CryptoProvider before any TLS call or rustls will panic. Ignore the
+    // error — a provider may already be installed by another build script
+    // running in the same process.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     let repo = format!("{VENDOR_REPO_PREFIX}/{target}");
     let base_url = format!("https://{VENDOR_REGISTRY}/v2/{repo}");
 


### PR DESCRIPTION
# Description


Fixes a panic in `build.rs` that prevents fresh builds of `drasi-server` on `x86_64-pc-windows-msvc`.

## Problem

On Windows MSVC, `build.rs` downloads pre-built native libraries (libjq, openssl) from `ghcr.io/drasi-project/vendor/` instead of compiling them from source. That download uses `ureq`, configured as a build-dependency with:

```toml
ureq = { version = "3", default-features = false, features = ["json", "rustls-no-provider", "rustls-webpki-roots"] }
rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
```

The `rustls-no-provider` feature means **no default `CryptoProvider` is registered automatically** — the build script is responsible for installing one before any TLS call. We never did, so the first HTTPS request to `ghcr.io` panicked:

```
thread 'main' panicked at ureq-3.3.0/src/tls/rustls.rs:154:9:
No CryptoProvider for Rustls. Either enable feature `rustls`, or set process
default using CryptoProvider::set_default(), or configure
TlsConfig::rustls_crypto_provider()
```

This made the very first `cargo build` / `cargo install` on a clean checkout fail on Windows MSVC. Subsequent builds appeared to work only because the download was cached in `vendor/` — running `rm -rf vendor && cargo clean && cargo build` reliably reproduces the panic.

## Why only Windows MSVC?

`download_vendor()` is gated on `VENDORED_TARGETS`, which currently contains only `x86_64-pc-windows-msvc`. macOS and Linux builds never enter the TLS code path (they compile native deps from source via the system toolchain), so the bug is invisible there.

## Fix

Install the `aws-lc-rs` `CryptoProvider` as the process default at the top of `download_vendor()`, before any `ureq` call. The result is ignored because another build script in the same process may have already installed a provider.

```rust
let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
```

## Testing

On Windows MSVC:

```powershell
Remove-Item -Recurse -Force vendor
cargo clean
cargo build --release
```

- **Before:** panics with `No CryptoProvider for Rustls`.
- **After:** vendored libs download from `ghcr.io`, build succeeds.

No behavior change on macOS or Linux (`download_vendor()` is not invoked).


## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now.

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
