### PR TITLE
updated windows msvc binary name in the Getting Started download script 

### DIFF
--- a/examples/getting-started/scripts/download.ps1
+++ b/examples/getting-started/scripts/download.ps1
@@ -20,7 +20,7 @@ Write-Host "Detected: Windows ($Arch)"
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 
 # Download drasi-server
-$ServerBinary = "drasi-server-x86_64-windows.exe"
+$ServerBinary = "drasi-server-x86_64-windows-msvc.exe"
 $ServerPath = Join-Path $InstallDir "drasi-server.exe"
 Write-Host "Downloading: $ServerBinary"
 try {


### PR DESCRIPTION
# Description

This pull request updates the Windows server binary name in the `download.ps1` script to match the new naming convention that includes the `-msvc` suffix.

Binary naming update:

* Changed the server binary from `drasi-server-x86_64-windows.exe` to `drasi-server-x86_64-windows-msvc.exe` in `download.ps1` to ensure the correct file is downloaded.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now.

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #114 
