### PR TITLE
ci: add nightly E2E consumer workflow 

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -1,0 +1,177 @@
+name: Nightly E2E (Consumer)
+
+# Consumer half of the end-to-end nightly pipeline. Triggered by drasi-core's
+# nightly.yml via repository_dispatch. It builds drasi-server against a specific
+# drasi-core `main` commit (overlaid with [patch.crates-io]) and runs the
+# integration test against the plugins drasi-core published to the nightly OCI
+# tag that same run.
+#
+# Payload from drasi-core (event_type: nightly-e2e):
+#   client_payload.core_sha    - drasi-core main HEAD SHA to build against
+#   client_payload.plugin_tag  - base OCI tag for nightly plugins (drasi-nightly-test)
+#   client_payload.registry    - OCI registry (ghcr.io/drasi-project)
+#
+# See drasi-core docs/nightly-e2e/README.md for the full design.
+
+on:
+  repository_dispatch:
+    types: [nightly-e2e]
+  workflow_dispatch:
+    inputs:
+      core_sha:
+        description: 'drasi-core main SHA (or branch/tag) to build against'
+        required: false
+        type: string
+        default: 'main'
+      plugin_tag:
+        description: 'Base OCI tag for nightly plugins'
+        required: false
+        type: string
+        default: 'drasi-nightly-test'
+      registry:
+        description: 'OCI registry to pull plugins from'
+        required: false
+        type: string
+        default: 'ghcr.io/drasi-project'
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  # Runner is linux/amd64; drasi-core publishes per-arch tags (the arch suffix is
+  # always appended, there is no multi-arch index), so plugins live under
+  # <tag>-linux-amd64.
+  ARCH_SUFFIX: linux-amd64
+
+jobs:
+  nightly-e2e:
+    name: Nightly E2E (server + latest core)
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_DB: getting_started
+          POSTGRES_USER: drasi_user
+          POSTGRES_PASSWORD: drasi_password
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - name: Resolve inputs
+        id: inputs
+        run: |
+          # repository_dispatch carries values under github.event.client_payload;
+          # workflow_dispatch carries them under github.event.inputs. Prefer the
+          # dispatch payload, fall back to manual inputs / defaults.
+          CORE_SHA='${{ github.event.client_payload.core_sha || inputs.core_sha || 'main' }}'
+          PLUGIN_TAG='${{ github.event.client_payload.plugin_tag || inputs.plugin_tag || 'drasi-nightly-test' }}'
+          REGISTRY='${{ github.event.client_payload.registry || inputs.registry || 'ghcr.io/drasi-project' }}'
+          echo "core_sha=$CORE_SHA" >> "$GITHUB_OUTPUT"
+          echo "plugin_tag=$PLUGIN_TAG" >> "$GITHUB_OUTPUT"
+          echo "registry=$REGISTRY" >> "$GITHUB_OUTPUT"
+          echo "Building drasi-server against drasi-core @ $CORE_SHA"
+          echo "Pulling plugins from $REGISTRY with tag ${PLUGIN_TAG}-${ARCH_SUFFIX}"
+
+      - name: Checkout drasi-server
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libjq-dev libonig-dev protobuf-compiler postgresql-client
+
+      - name: Set JQ_LIB_DIR
+        run: echo "JQ_LIB_DIR=/usr/lib/x86_64-linux-gnu" >> $GITHUB_ENV
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      # Overlay the drasi-core crates from the target commit without touching the
+      # committed dependency versions. Every drasi-* crate the server pulls from
+      # crates.io is redirected to the same drasi-core commit, so the build tests
+      # tonight's core. Auto-generated from the manifest so it stays in sync as
+      # dependencies are added/removed.
+      - name: Apply [patch.crates-io] overlay to drasi-core commit
+        env:
+          CORE_SHA: ${{ steps.inputs.outputs.core_sha }}
+        run: |
+          set -euo pipefail
+          REPO="https://github.com/drasi-project/drasi-core"
+          CRATES=$(grep -oE '^drasi-[a-z0-9-]+' Cargo.toml | sort -u)
+          if [ -z "$CRATES" ]; then
+            echo "::error::No drasi-* crates found in Cargo.toml to patch"
+            exit 1
+          fi
+          {
+            echo ""
+            echo "# --- nightly-e2e overlay (CI only) ---"
+            echo "[patch.crates-io]"
+            for c in $CRATES; do
+              echo "$c = { git = \"$REPO\", rev = \"$CORE_SHA\" }"
+            done
+          } >> Cargo.toml
+          echo "=== Applied overlay ==="
+          tail -n 20 Cargo.toml
+
+      - name: Build Drasi Server against patched core
+        run: cargo build --release
+
+      - name: Setup PostgreSQL database
+        run: |
+          export RESTART_CONTAINER=true
+          ./tests/integration/getting-started/setup-postgres.sh
+
+      # Option A: disable auto-install and install each plugin explicitly with the
+      # nightly OCI tag, so we exercise tonight's freshly published plugins rather
+      # than the released ones. Signature verification is skipped because the
+      # nightly -test channel is unsigned.
+      - name: Install nightly plugins
+        env:
+          PLUGIN_TAG: ${{ steps.inputs.outputs.plugin_tag }}
+          REGISTRY: ${{ steps.inputs.outputs.registry }}
+        run: |
+          set -euo pipefail
+          BIN=target/release/drasi-server
+          TAG="${PLUGIN_TAG}-${ARCH_SUFFIX}"
+          for ref in source/postgres bootstrap/postgres reaction/log; do
+            echo "=== Installing ${ref}:${TAG} from ${REGISTRY} ==="
+            "$BIN" plugin install "${ref}:${TAG}" \
+              --registry "${REGISTRY}" \
+              --skip-verification
+          done
+
+      # Reuse the existing getting-started test, but with a config that has
+      # auto-install disabled so the server loads the plugins we installed above.
+      - name: Prepare nightly config (disable auto-install)
+        run: |
+          set -euo pipefail
+          SRC=tests/integration/getting-started/config.yaml
+          DST=tests/integration/getting-started/config.nightly.yaml
+          sed 's/^autoInstallPlugins:.*/autoInstallPlugins: false/' "$SRC" > "$DST"
+          echo "=== nightly config plugin/install settings ==="
+          grep -E 'autoInstallPlugins|verifyPlugins' "$DST"
+
+      - name: Run integration tests
+        env:
+          CONFIG_FILE: ${{ github.workspace }}/tests/integration/getting-started/config.nightly.yaml
+        run: ./tests/integration/getting-started/run-integration-test.sh
+
+      - name: Show server logs on failure
+        if: failure()
+        run: |
+          echo "=== Server logs ==="
+          if [ -f tests/integration/getting-started/server.log ]; then
+            cat tests/integration/getting-started/server.log
+          else
+            echo "No server log file found"
+          fi

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -127,7 +127,13 @@ jobs:
           submodules: recursive
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libjq-dev libonig-dev protobuf-compiler postgresql-client
+        run: |
+          # The Microsoft apt repos preinstalled on GitHub runners intermittently
+          # serve a broken InRelease signature (NOSPLIT), failing apt-get update.
+          # We don't use them, so remove before updating.
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/azure-cli.sources 2>/dev/null || true
+          sudo apt-get update
+          sudo apt-get install -y libjq-dev libonig-dev protobuf-compiler postgresql-client
 
       - name: Set JQ_LIB_DIR
         run: echo "JQ_LIB_DIR=/usr/lib/x86_64-linux-gnu" >> $GITHUB_ENV
@@ -135,32 +141,49 @@ jobs:
       - name: Install Rust toolchain
         run: rustup show
 
-      # Overlay the drasi-core crates from the target commit without touching the
-      # committed dependency versions. Every drasi-* crate the server pulls from
-      # crates.io is redirected to the same drasi-core commit, so the build tests
-      # tonight's core. Auto-generated from the manifest so it stays in sync as
-      # dependencies are added/removed.
-      - name: Apply [patch.crates-io] overlay to drasi-core commit
+      # Point every drasi-* dependency at the target drasi-core commit by rewriting
+      # them to direct git dependencies. We do NOT use [patch.crates-io] here: a
+      # patch is silently ignored when the git version doesn't satisfy the crate's
+      # crates.io version requirement (e.g. server requires drasi-plugin-sdk 0.9.1
+      # but main is 0.10.0), which leaves TWO versions of the SDK in the graph and
+      # breaks trait resolution. A direct git dependency has no version gate, so all
+      # drasi crates resolve to drasi-core's exact versions from the same workspace
+      # checkout — a single version of each. Committed versions/features are
+      # preserved except the source; nothing is relaxed.
+      - name: Overlay drasi-core deps to target commit (git deps)
         env:
           CORE_SHA: ${{ steps.inputs.outputs.core_sha }}
         run: |
           set -euo pipefail
-          REPO="https://github.com/drasi-project/drasi-core"
-          CRATES=$(grep -oE '^drasi-[a-z0-9-]+' Cargo.toml | sort -u)
-          if [ -z "$CRATES" ]; then
-            echo "::error::No drasi-* crates found in Cargo.toml to patch"
-            exit 1
-          fi
-          {
-            echo ""
-            echo "# --- nightly-e2e overlay (CI only) ---"
-            echo "[patch.crates-io]"
-            for c in $CRATES; do
-              echo "$c = { git = \"$REPO\", rev = \"$CORE_SHA\" }"
-            done
-          } >> Cargo.toml
-          echo "=== Applied overlay ==="
-          tail -n 20 Cargo.toml
+          python3 - "$CORE_SHA" <<'PY'
+          import re, sys
+          sha = sys.argv[1]
+          repo = "https://github.com/drasi-project/drasi-core"
+          text = open("Cargo.toml").read()
+
+          # Match top-level (non-comment) drasi-* dependency declarations, either
+          #   drasi-x = "1.2.3"
+          # or an inline/multi-line table
+          #   drasi-x = { version = "1.2.3", features = [ ... ] }
+          # The table body has no nested '}', so [^}]* spans the multi-line features.
+          pattern = re.compile(r'^(drasi-[a-z0-9-]+)\s*=\s*("[^"]*"|\{[^}]*\})', re.M)
+
+          def repl(m):
+              name, body = m.group(1), m.group(2)
+              feat = ""
+              fm = re.search(r'features\s*=\s*(\[[^\]]*\])', body, re.S)
+              if fm:
+                  feat = f', features = {fm.group(1)}'
+              return f'{name} = {{ git = "{repo}", rev = "{sha}"{feat} }}'
+
+          new = pattern.sub(repl, text)
+          if new == text:
+              print("::error::No drasi-* dependencies were rewritten", file=sys.stderr)
+              sys.exit(1)
+          open("Cargo.toml", "w").write(new)
+          PY
+          echo "=== Rewritten drasi-* dependencies ==="
+          grep -nE '^drasi-[a-z0-9-]+ *=' Cargo.toml || true
 
       - name: Build Drasi Server against patched core
         run: cargo build --release

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -33,6 +33,36 @@ on:
         required: false
         type: string
         default: 'ghcr.io/drasi-project'
+  # Called directly by drasi-core's nightly.yml (uses: .../nightly-e2e.yml@<ref>).
+  # When called cross-repo the job runs in the CALLER's context, so server_repo /
+  # server_ref are required to check out drasi-server (not drasi-core).
+  workflow_call:
+    inputs:
+      core_sha:
+        description: 'drasi-core SHA/branch/tag to build against'
+        required: false
+        type: string
+        default: 'main'
+      plugin_tag:
+        description: 'Base OCI tag for nightly plugins'
+        required: false
+        type: string
+        default: 'drasi-nightly-test'
+      registry:
+        description: 'OCI registry to pull plugins from'
+        required: false
+        type: string
+        default: 'ghcr.io/drasi-project'
+      server_repo:
+        description: 'drasi-server repository to check out (owner/name)'
+        required: false
+        type: string
+        default: 'drasi-project/drasi-server'
+      server_ref:
+        description: 'drasi-server ref to check out (branch/tag/SHA)'
+        required: false
+        type: string
+        default: 'main'
 
 permissions:
   contents: read
@@ -85,6 +115,12 @@ jobs:
       - name: Checkout drasi-server
         uses: actions/checkout@v6
         with:
+          # For native triggers (repository_dispatch / workflow_dispatch) inputs
+          # are unset, so these fall back to this repo at the triggering ref. For
+          # a cross-repo workflow_call the caller passes server_repo/server_ref so
+          # we check out drasi-server rather than the caller (drasi-core).
+          repository: ${{ inputs.server_repo || github.repository }}
+          ref: ${{ inputs.server_ref || github.ref }}
           submodules: recursive
 
       - name: Install system dependencies

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -1,24 +1,21 @@
 name: Nightly E2E (Consumer)
 
-# Consumer half of the end-to-end nightly pipeline. Triggered by drasi-core's
-# nightly.yml via repository_dispatch. It builds drasi-server against a specific
-# drasi-core `main` commit (overlaid with [patch.crates-io]) and runs the
-# integration test against the plugins drasi-core published to the nightly OCI
-# tag that same run.
+# Consumer half of the end-to-end nightly pipeline. Called by drasi-core's
+# nightly.yml via a cross-repo `workflow_call`. It builds drasi-server against a
+# specific drasi-core commit (by rewriting the drasi-* dependencies to git deps
+# pinned at that commit) and runs the integration test against the plugins
+# drasi-core published to the nightly OCI tag in that same run.
 #
-# Payload from drasi-core (event_type: nightly-e2e):
-#   client_payload.core_sha    - drasi-core main HEAD SHA to build against
-#   client_payload.plugin_tag  - base OCI tag for nightly plugins (drasi-nightly-test)
-#   client_payload.registry    - OCI registry (ghcr.io/drasi-project)
+# Inputs (from drasi-core, or from workflow_dispatch for manual runs):
+#   core_sha    - drasi-core SHA/branch/tag to build against
+#   plugin_tag  - base OCI tag for nightly plugins (drasi-nightly-test)
+#   registry    - OCI registry (ghcr.io/drasi-project)
+#   server_repo / server_ref - which drasi-server checkout to build (workflow_call
+#                 runs in the CALLER's context, so these are required cross-repo)
 #
 # See drasi-core docs/nightly-e2e/README.md for the full design.
 
 on:
-  push:
-    branches:
-      - drasi-e2e-nightly
-  repository_dispatch:
-    types: [nightly-e2e]
   workflow_dispatch:
     inputs:
       core_sha:
@@ -103,12 +100,11 @@ jobs:
       - name: Resolve inputs
         id: inputs
         run: |
-          # repository_dispatch carries values under github.event.client_payload;
-          # workflow_dispatch carries them under github.event.inputs. Prefer the
-          # dispatch payload, fall back to manual inputs / defaults.
-          CORE_SHA='${{ github.event.client_payload.core_sha || inputs.core_sha || 'main' }}'
-          PLUGIN_TAG='${{ github.event.client_payload.plugin_tag || inputs.plugin_tag || 'drasi-nightly-test' }}'
-          REGISTRY='${{ github.event.client_payload.registry || inputs.registry || 'ghcr.io/drasi-project' }}'
+          # Values come from workflow_call (drasi-core) or workflow_dispatch
+          # (manual); both surface as `inputs.*`. Defaults cover a bare manual run.
+          CORE_SHA='${{ inputs.core_sha || 'main' }}'
+          PLUGIN_TAG='${{ inputs.plugin_tag || 'drasi-nightly-test' }}'
+          REGISTRY='${{ inputs.registry || 'ghcr.io/drasi-project' }}'
           echo "core_sha=$CORE_SHA" >> "$GITHUB_OUTPUT"
           echo "plugin_tag=$PLUGIN_TAG" >> "$GITHUB_OUTPUT"
           echo "registry=$REGISTRY" >> "$GITHUB_OUTPUT"
@@ -118,10 +114,10 @@ jobs:
       - name: Checkout drasi-server
         uses: actions/checkout@v6
         with:
-          # For native triggers (repository_dispatch / workflow_dispatch) inputs
-          # are unset, so these fall back to this repo at the triggering ref. For
-          # a cross-repo workflow_call the caller passes server_repo/server_ref so
-          # we check out drasi-server rather than the caller (drasi-core).
+          # For a manual workflow_dispatch run these fall back to this repo at the
+          # triggering ref. For a cross-repo workflow_call the caller passes
+          # server_repo/server_ref so we check out drasi-server rather than the
+          # caller (drasi-core).
           repository: ${{ inputs.server_repo || github.repository }}
           ref: ${{ inputs.server_ref || github.ref }}
           submodules: recursive

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -34,8 +34,10 @@ on:
         type: string
         default: 'ghcr.io/drasi-project'
   # Called directly by drasi-core's nightly.yml (uses: .../nightly-e2e.yml@<ref>).
-  # When called cross-repo the job runs in the CALLER's context, so server_repo /
-  # server_ref are required to check out drasi-server (not drasi-core).
+  # A cross-repo workflow_call runs in the CALLER's context, so server_repo /
+  # server_ref control which drasi-server checkout to build. They are optional:
+  # the defaults (drasi-project/drasi-server @ main) already target this repo, and
+  # a caller only overrides them to build a different branch/SHA.
   workflow_call:
     inputs:
       core_sha:
@@ -99,15 +101,31 @@ jobs:
     steps:
       - name: Resolve inputs
         id: inputs
+        env:
+          # Pass inputs via env (not direct ${{ }} interpolation into the script)
+          # so untrusted values can't break out of the shell / inject GITHUB_OUTPUT.
+          INPUT_CORE_SHA: ${{ inputs.core_sha }}
+          INPUT_PLUGIN_TAG: ${{ inputs.plugin_tag }}
+          INPUT_REGISTRY: ${{ inputs.registry }}
         run: |
-          # Values come from workflow_call (drasi-core) or workflow_dispatch
-          # (manual); both surface as `inputs.*`. Defaults cover a bare manual run.
-          CORE_SHA='${{ inputs.core_sha || 'main' }}'
-          PLUGIN_TAG='${{ inputs.plugin_tag || 'drasi-nightly-test' }}'
-          REGISTRY='${{ inputs.registry || 'ghcr.io/drasi-project' }}'
-          echo "core_sha=$CORE_SHA" >> "$GITHUB_OUTPUT"
-          echo "plugin_tag=$PLUGIN_TAG" >> "$GITHUB_OUTPUT"
-          echo "registry=$REGISTRY" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          # Values come from workflow_call (drasi-core) or workflow_dispatch (manual);
+          # defaults cover a bare manual run.
+          CORE_SHA="${INPUT_CORE_SHA:-main}"
+          PLUGIN_TAG="${INPUT_PLUGIN_TAG:-drasi-nightly-test}"
+          REGISTRY="${INPUT_REGISTRY:-ghcr.io/drasi-project}"
+
+          # Strip any newlines to prevent injection into $GITHUB_OUTPUT.
+          CORE_SHA="${CORE_SHA//$'\n'/}"
+          PLUGIN_TAG="${PLUGIN_TAG//$'\n'/}"
+          REGISTRY="${REGISTRY//$'\n'/}"
+
+          {
+            printf 'core_sha=%s\n' "$CORE_SHA"
+            printf 'plugin_tag=%s\n' "$PLUGIN_TAG"
+            printf 'registry=%s\n' "$REGISTRY"
+          } >> "$GITHUB_OUTPUT"
+
           echo "Building drasi-server against drasi-core @ $CORE_SHA"
           echo "Pulling plugins from $REGISTRY with base tag ${PLUGIN_TAG} (resolver appends arch suffix, e.g. -${ARCH_SUFFIX})"
 

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -14,6 +14,9 @@ name: Nightly E2E (Consumer)
 # See drasi-core docs/nightly-e2e/README.md for the full design.
 
 on:
+  push:
+    branches:
+      - drasi-e2e-nightly
   repository_dispatch:
     types: [nightly-e2e]
   workflow_dispatch:
@@ -110,7 +113,7 @@ jobs:
           echo "plugin_tag=$PLUGIN_TAG" >> "$GITHUB_OUTPUT"
           echo "registry=$REGISTRY" >> "$GITHUB_OUTPUT"
           echo "Building drasi-server against drasi-core @ $CORE_SHA"
-          echo "Pulling plugins from $REGISTRY with tag ${PLUGIN_TAG}-${ARCH_SUFFIX}"
+          echo "Pulling plugins from $REGISTRY with base tag ${PLUGIN_TAG} (resolver appends arch suffix, e.g. -${ARCH_SUFFIX})"
 
       - name: Checkout drasi-server
         uses: actions/checkout@v6
@@ -178,7 +181,11 @@ jobs:
         run: |
           set -euo pipefail
           BIN=target/release/drasi-server
-          TAG="${PLUGIN_TAG}-${ARCH_SUFFIX}"
+          # Pass the BASE tag only. The plugin resolver automatically appends the
+          # platform arch suffix (e.g. -linux-amd64) when pulling, so the images
+          # published as drasi-nightly-test-linux-amd64 are matched. Passing the
+          # arch-suffixed tag here would double it (…-linux-amd64-linux-amd64).
+          TAG="${PLUGIN_TAG}"
           for ref in source/postgres bootstrap/postgres reaction/log; do
             echo "=== Installing ${ref}:${TAG} from ${REGISTRY} ==="
             "$BIN" plugin install "${ref}:${TAG}" \


### PR DESCRIPTION
# Description

## What

Adds `.github/workflows/nightly-e2e.yml` — the drasi-server half of the
cross-repo nightly end-to-end pipeline. It builds drasi-server against the latest
drasi-core commit and runs the getting-started integration test against
freshly-published nightly plugins, so we catch core→server breakage within a day
instead of at release time.

This is the **consumer** side. The **producer** side (which resolves the core SHA,
publishes the nightly plugins, and calls this workflow) lands in a companion
drasi-core PR. Full design: `drasi-core/docs/nightly-e2e/README.md`.

## How it works

Triggered via cross-repo `workflow_call` from drasi-core's `nightly.yml`
(also runnable manually via `workflow_dispatch`). Steps:

1. **Overlay drasi-core deps → git deps at the target commit.** Every `drasi-*`
   dependency in `Cargo.toml` is rewritten to a direct git dependency pinned to
   the core SHA (features preserved; CI-only edit on the ephemeral runner).
2. **Build** drasi-server against that core.
3. **Install nightly plugins** — pulls `source/postgres`, `bootstrap/postgres`,
   `reaction/log` from `ghcr.io/drasi-project` at the `drasi-nightly-test` tag,
   with auto-install disabled so the server loads exactly these.
4. **Run** the existing getting-started integration test (Postgres CDC e2e).

## Why git-dependency overlay, not `[patch.crates-io]`

A `[patch.crates-io]` is **silently ignored** when the git version doesn't satisfy
the crate's crates.io version requirement. When core bumps (e.g. `drasi-plugin-sdk`
0.9.1 → 0.10.0) but the server still requests `0.9.1`, the patch is dropped —
leaving two SDK versions in the graph and breaking trait resolution. Direct git
dependencies have no version gate, so all drasi crates resolve to core's exact
versions from one workspace checkout. Nothing is relaxed.

## Notes

- Inputs: `core_sha`, `plugin_tag`, `registry`, `server_repo`, `server_ref`
  (the last two are required because a cross-repo `workflow_call` runs in the
  caller's context).
- Signature verification is skipped for the unsigned nightly `-test` channel.
- Removes flaky preinstalled Microsoft apt repos before `apt-get update` (avoids
  intermittent `NOSPLIT` failures on GitHub runners).
- No PR/push trigger: this workflow only runs on the nightly schedule (via the
  drasi-core caller) or on-demand.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now.

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
