### PR TITLE
Update drasi-lib to use middleware-bundled-jq

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,10 @@ name = "drasi-server"
 path = "src/main.rs"
 
 [dependencies]
-# Drasi core library (all middleware, using system libjq instead of bundled-jq)
+# Drasi core library (all middleware, using bundled-jq so the binary statically
+# links jq/oniguruma and needs no system libjq at runtime).
 drasi-lib = { version = "0.8.8", features = [
-  "middleware-jq",
+  "middleware-bundled-jq",
   "middleware-decoder",
   "middleware-map",
   "middleware-parse-json",


### PR DESCRIPTION
# Description

This pull request updates the `drasi-lib` dependency configuration in `Cargo.toml` to use the bundled version of `jq` instead of relying on the system-installed `libjq`. This change ensures that the resulting binary is statically linked with `jq` and `oniguruma`, eliminating the need for these libraries to be present on the system at runtime.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now.

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
