### PR TITLE
Elevate bootstrap providers to top-level config components 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,32 @@ enableUi: true       # Enable the web UI at /ui (default: true)
 #   - "http://localhost:3000"
 #   - "https://dashboard.example.com"
 
+# Optional top-level bootstrap providers, referenced by sources via
+# `bootstrapProvider: <id>`. Declaring a provider here lets multiple sources
+# share one definition. Each referencing source instantiates its own provider
+# instance from this config (non-singleton).
+# bootstrapProviders:
+#   - kind: postgres
+#     id: pg-bootstrap
+#     host: localhost
+#     port: 5432
+#     database: mydb
+#     user: drasi
+#     password: "${PG_PASSWORD}"
+#     tables: [Message]
+#
+# A source then references it by id (see the sources block below):
+#   sources:
+#     - kind: postgres
+#       id: my-source
+#       bootstrapProvider: pg-bootstrap   # reference to the top-level entry
+#
+# Sources may also define a bootstrap provider INLINE (a mapping instead of a
+# string). An inline provider of the SAME kind as its source inherits the
+# source's connection fields, so it needs no duplication:
+#   bootstrapProvider:
+#     kind: postgres
+
 # Sources (parsed into plugin instances)
 sources:
   - kind: mock

--- a/examples/basic_setup.rs
+++ b/examples/basic_setup.rs
@@ -115,6 +115,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         solutions_dir: None, // Use default solutions directory
         cors_allowed_origins: vec![],
         identity_providers: vec![],
+        bootstrap_providers: vec![],
     };
 
     // Save configuration to file

--- a/src/api/models/bootstrap.rs
+++ b/src/api/models/bootstrap.rs
@@ -31,6 +31,10 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq)]
 pub struct BootstrapProviderConfig {
     pub kind: String,
+    /// Optional identifier. Required for top-level `bootstrapProviders`
+    /// entries (which sources reference via `bootstrapProvider: <id>`).
+    /// Inline bootstrap providers nested under a source leave this `None`.
+    pub id: Option<String>,
     pub config: serde_json::Value,
 }
 
@@ -38,6 +42,44 @@ impl BootstrapProviderConfig {
     /// Get the kind string for this bootstrap provider config.
     pub fn kind(&self) -> &str {
         &self.kind
+    }
+
+    /// Get the optional id of this bootstrap provider config.
+    pub fn id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+}
+
+/// A source's bootstrap provider: either a reference (by id) to a top-level
+/// `bootstrapProviders` entry, or an inline definition nested under the source.
+///
+/// The reference form (a YAML/JSON string) enables sharing a single top-level
+/// bootstrap provider configuration across multiple sources. The inline form
+/// (a mapping) preserves the legacy behaviour where the bootstrap provider can
+/// inherit fields from the owning source's config.
+#[derive(Debug, Clone, PartialEq)]
+pub enum BootstrapProviderRef {
+    /// Reference to a top-level `bootstrapProviders` entry by id.
+    Reference(String),
+    /// Inline bootstrap provider definition.
+    Inline(BootstrapProviderConfig),
+}
+
+impl BootstrapProviderRef {
+    /// Return the inline config, if this is the inline form.
+    pub fn as_inline(&self) -> Option<&BootstrapProviderConfig> {
+        match self {
+            Self::Inline(config) => Some(config),
+            Self::Reference(_) => None,
+        }
+    }
+
+    /// Return the referenced id, if this is the reference form.
+    pub fn as_reference(&self) -> Option<&str> {
+        match self {
+            Self::Reference(id) => Some(id.as_str()),
+            Self::Inline(_) => None,
+        }
     }
 }
 
@@ -49,6 +91,9 @@ impl Serialize for BootstrapProviderConfig {
         use serde::ser::SerializeMap;
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("kind", &self.kind)?;
+        if let Some(id) = &self.id {
+            map.serialize_entry("id", id)?;
+        }
         if let serde_json::Value::Object(config_map) = &self.config {
             for (k, v) in config_map {
                 map.serialize_entry(k, v)?;
@@ -77,6 +122,7 @@ impl<'de> Deserialize<'de> for BootstrapProviderConfig {
                 M: MapAccess<'de>,
             {
                 let mut provider_kind: Option<String> = None;
+                let mut id: Option<String> = None;
                 let mut remaining = serde_json::Map::new();
 
                 while let Some(key) = map.next_key::<String>()? {
@@ -86,6 +132,12 @@ impl<'de> Deserialize<'de> for BootstrapProviderConfig {
                                 return Err(de::Error::duplicate_field("kind"));
                             }
                             provider_kind = Some(map.next_value()?);
+                        }
+                        "id" => {
+                            if id.is_some() {
+                                return Err(de::Error::duplicate_field("id"));
+                            }
+                            id = Some(map.next_value()?);
                         }
                         other => {
                             let value: serde_json::Value = map.next_value()?;
@@ -98,7 +150,7 @@ impl<'de> Deserialize<'de> for BootstrapProviderConfig {
 
                 let config = serde_json::Value::Object(remaining);
 
-                Ok(BootstrapProviderConfig { kind, config })
+                Ok(BootstrapProviderConfig { kind, id, config })
             }
         }
 
@@ -140,6 +192,7 @@ filePaths:
     fn test_serialization_roundtrip() {
         let config = BootstrapProviderConfig {
             kind: "scriptfile".to_string(),
+            id: None,
             config: serde_json::json!({
                 "filePaths": ["/test.jsonl"]
             }),

--- a/src/api/models/bootstrap.rs
+++ b/src/api/models/bootstrap.rs
@@ -28,13 +28,14 @@ use std::fmt;
 /// Bootstrap providers handle initial data delivery for newly subscribed queries.
 /// This generic struct stores the provider kind and plugin-specific configuration
 /// as a JSON value, similar to SourceConfig and ReactionConfig.
+///
+/// This type is intentionally **id-free**: it describes an inline bootstrap
+/// provider nested under a source. Top-level, referenceable providers are
+/// represented by [`TopLevelBootstrapProviderConfig`], which adds a required
+/// `id`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct BootstrapProviderConfig {
     pub kind: String,
-    /// Optional identifier. Required for top-level `bootstrapProviders`
-    /// entries (which sources reference via `bootstrapProvider: <id>`).
-    /// Inline bootstrap providers nested under a source leave this `None`.
-    pub id: Option<String>,
     pub config: serde_json::Value,
 }
 
@@ -43,10 +44,29 @@ impl BootstrapProviderConfig {
     pub fn kind(&self) -> &str {
         &self.kind
     }
+}
 
-    /// Get the optional id of this bootstrap provider config.
-    pub fn id(&self) -> Option<&str> {
-        self.id.as_deref()
+/// A top-level, referenceable bootstrap provider: a [`BootstrapProviderConfig`]
+/// plus a required `id`. Sources reference these via `bootstrapProvider: <id>`.
+///
+/// Keeping the `id` in a dedicated wrapper (rather than an optional field on
+/// [`BootstrapProviderConfig`]) lets the "top-level entries require an id"
+/// constraint be enforced structurally instead of via runtime validation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TopLevelBootstrapProviderConfig {
+    pub id: String,
+    pub inner: BootstrapProviderConfig,
+}
+
+impl TopLevelBootstrapProviderConfig {
+    /// Get the id of this top-level bootstrap provider.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Get the kind of this top-level bootstrap provider.
+    pub fn kind(&self) -> &str {
+        self.inner.kind()
     }
 }
 
@@ -55,7 +75,7 @@ impl BootstrapProviderConfig {
 ///
 /// The reference form (a YAML/JSON string) enables sharing a single top-level
 /// bootstrap provider configuration across multiple sources. The inline form
-/// (a mapping) preserves the legacy behaviour where the bootstrap provider can
+/// (a mapping) preserves the legacy behavior where the bootstrap provider can
 /// inherit fields from the owning source's config.
 #[derive(Debug, Clone, PartialEq)]
 pub enum BootstrapProviderRef {
@@ -91,9 +111,6 @@ impl Serialize for BootstrapProviderConfig {
         use serde::ser::SerializeMap;
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("kind", &self.kind)?;
-        if let Some(id) = &self.id {
-            map.serialize_entry("id", id)?;
-        }
         if let serde_json::Value::Object(config_map) = &self.config {
             for (k, v) in config_map {
                 map.serialize_entry(k, v)?;
@@ -115,6 +132,72 @@ impl<'de> Deserialize<'de> for BootstrapProviderConfig {
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("a bootstrap provider configuration with 'kind' field")
+            }
+
+            fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                let mut provider_kind: Option<String> = None;
+                let mut remaining = serde_json::Map::new();
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "kind" => {
+                            if provider_kind.is_some() {
+                                return Err(de::Error::duplicate_field("kind"));
+                            }
+                            provider_kind = Some(map.next_value()?);
+                        }
+                        other => {
+                            let value: serde_json::Value = map.next_value()?;
+                            remaining.insert(other.to_string(), value);
+                        }
+                    }
+                }
+
+                let kind = provider_kind.ok_or_else(|| de::Error::missing_field("kind"))?;
+
+                let config = serde_json::Value::Object(remaining);
+
+                Ok(BootstrapProviderConfig { kind, config })
+            }
+        }
+
+        deserializer.deserialize_map(BootstrapProviderConfigVisitor)
+    }
+}
+
+impl Serialize for TopLevelBootstrapProviderConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("kind", &self.inner.kind)?;
+        map.serialize_entry("id", &self.id)?;
+        if let serde_json::Value::Object(config_map) = &self.inner.config {
+            for (k, v) in config_map {
+                map.serialize_entry(k, v)?;
+            }
+        }
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for TopLevelBootstrapProviderConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct TopLevelVisitor;
+
+        impl<'de> Visitor<'de> for TopLevelVisitor {
+            type Value = TopLevelBootstrapProviderConfig;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a top-level bootstrap provider with 'kind' and 'id' fields")
             }
 
             fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
@@ -147,14 +230,19 @@ impl<'de> Deserialize<'de> for BootstrapProviderConfig {
                 }
 
                 let kind = provider_kind.ok_or_else(|| de::Error::missing_field("kind"))?;
+                let id = id.ok_or_else(|| de::Error::missing_field("id"))?;
 
-                let config = serde_json::Value::Object(remaining);
-
-                Ok(BootstrapProviderConfig { kind, id, config })
+                Ok(TopLevelBootstrapProviderConfig {
+                    id,
+                    inner: BootstrapProviderConfig {
+                        kind,
+                        config: serde_json::Value::Object(remaining),
+                    },
+                })
             }
         }
 
-        deserializer.deserialize_map(BootstrapProviderConfigVisitor)
+        deserializer.deserialize_map(TopLevelVisitor)
     }
 }
 
@@ -192,7 +280,6 @@ filePaths:
     fn test_serialization_roundtrip() {
         let config = BootstrapProviderConfig {
             kind: "scriptfile".to_string(),
-            id: None,
             config: serde_json::json!({
                 "filePaths": ["/test.jsonl"]
             }),
@@ -203,5 +290,33 @@ filePaths:
 
         let deserialized: BootstrapProviderConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(config, deserialized);
+    }
+
+    #[test]
+    fn test_top_level_roundtrip_and_requires_id() {
+        let yaml = r#"
+kind: postgres
+id: pg-bootstrap
+host: localhost
+tables:
+  - Message
+"#;
+        let cfg: TopLevelBootstrapProviderConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.id(), "pg-bootstrap");
+        assert_eq!(cfg.kind(), "postgres");
+        assert_eq!(cfg.inner.config["host"], "localhost");
+
+        // Round-trips through serialize/deserialize.
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: TopLevelBootstrapProviderConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(cfg, back);
+
+        // Missing id is a hard error (structurally enforced).
+        let err = serde_yaml::from_str::<TopLevelBootstrapProviderConfig>("kind: postgres\n")
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("id"),
+            "expected missing id error: {err}"
+        );
     }
 }

--- a/src/api/models/mod.rs
+++ b/src/api/models/mod.rs
@@ -46,7 +46,7 @@ pub mod source;
 pub mod state_store;
 
 // Re-export all DTO types for convenient access
-pub use bootstrap::BootstrapProviderConfig;
+pub use bootstrap::{BootstrapProviderConfig, BootstrapProviderRef};
 pub use drasi_plugin_sdk::config_value::*;
 pub use identity_provider::{IdentityProviderConfig, BUILTIN_PASSWORD_KIND};
 pub use observability::*;

--- a/src/api/models/mod.rs
+++ b/src/api/models/mod.rs
@@ -46,7 +46,9 @@ pub mod source;
 pub mod state_store;
 
 // Re-export all DTO types for convenient access
-pub use bootstrap::{BootstrapProviderConfig, BootstrapProviderRef};
+pub use bootstrap::{
+    BootstrapProviderConfig, BootstrapProviderRef, TopLevelBootstrapProviderConfig,
+};
 pub use drasi_plugin_sdk::config_value::*;
 pub use identity_provider::{IdentityProviderConfig, BUILTIN_PASSWORD_KIND};
 pub use observability::*;

--- a/src/api/models/source.rs
+++ b/src/api/models/source.rs
@@ -270,47 +270,32 @@ fn merge_bootstrap_provider_with_source(
         _ => return serde_json::Value::Object(bootstrap_map),
     };
 
+    // Inheritance only applies when the bootstrap provider is the SAME kind as
+    // the source, since they then share a config schema. For mix-and-match
+    // (a different bootstrapper kind) the provider must be configured
+    // explicitly — inheriting source fields into a different schema would be
+    // meaningless or wrong.
     if bootstrap_kind != source_kind {
         return serde_json::Value::Object(bootstrap_map);
     }
-
-    let Some(allowed_fields) = allowed_bootstrap_provider_fields(bootstrap_kind) else {
-        return serde_json::Value::Object(bootstrap_map);
-    };
 
     let serde_json::Value::Object(source_map) = source_config else {
         return serde_json::Value::Object(bootstrap_map);
     };
 
-    for field in allowed_fields {
-        if !bootstrap_map.contains_key(*field) {
-            if let Some(value) = source_map.get(*field) {
-                bootstrap_map.insert((*field).to_string(), value.clone());
-            }
+    // Inherit every source field the bootstrap provider hasn't already set.
+    // This is generic across all plugin kinds — there is no per-kind allowlist —
+    // so, e.g., a MySQL source with an inline `{ kind: mysql }` bootstrap
+    // provider automatically reuses the same connection settings without any
+    // server-side changes. Fields explicitly set on the bootstrap provider
+    // always take precedence.
+    for (field, value) in source_map {
+        if !bootstrap_map.contains_key(field) {
+            bootstrap_map.insert(field.clone(), value.clone());
         }
     }
 
     serde_json::Value::Object(bootstrap_map)
-}
-
-fn allowed_bootstrap_provider_fields(kind: &str) -> Option<&'static [&'static str]> {
-    match kind {
-        "postgres" => Some(&[
-            "host",
-            "port",
-            "database",
-            "user",
-            "password",
-            "tables",
-            "slotName",
-            "publicationName",
-            "sslMode",
-            "tableKeys",
-        ]),
-        "scriptfile" => Some(&["filePaths"]),
-        "application" | "noop" => Some(&[]),
-        _ => None,
-    }
 }
 
 // =============================================================================
@@ -638,6 +623,71 @@ bootstrapProvider:
         assert_eq!(bp.config["user"], "bootstrap_user");
         // Inherited field
         assert_eq!(bp.config["password"], "drasi_pass");
+    }
+
+    #[test]
+    fn test_bootstrap_provider_inherits_generic_kind() {
+        // Inheritance is generic across plugin kinds (no hardcoded allowlist):
+        // a same-kind inline bootstrap provider inherits ALL source fields it
+        // does not itself set. This exercises a kind that was never special-cased.
+        let yaml = r#"
+kind: mysql
+id: mysql-source
+host: db.internal
+port: 3306
+database: shop
+user: app
+password: s3cret
+tables:
+- Orders
+bootstrapProvider:
+  kind: mysql
+"#;
+
+        let source: SourceConfig = serde_yaml::from_str(yaml).unwrap();
+        let bp = source
+            .bootstrap_provider()
+            .and_then(|r| r.as_inline())
+            .expect("Expected inline bootstrap provider");
+        assert_eq!(bp.kind(), "mysql");
+        // Every source field is inherited without any per-kind configuration.
+        assert_eq!(bp.config["host"], "db.internal");
+        assert_eq!(bp.config["port"], 3306);
+        assert_eq!(bp.config["database"], "shop");
+        assert_eq!(bp.config["user"], "app");
+        assert_eq!(bp.config["password"], "s3cret");
+        assert_eq!(bp.config["tables"][0], "Orders");
+    }
+
+    #[test]
+    fn test_bootstrap_provider_different_kind_does_not_inherit() {
+        // Mix-and-match: a bootstrap provider of a DIFFERENT kind than the
+        // source must be configured explicitly and inherits nothing.
+        let yaml = r#"
+kind: mysql
+id: mysql-source
+host: db.internal
+port: 3306
+database: shop
+user: app
+password: s3cret
+bootstrapProvider:
+  kind: scriptfile
+  filePaths:
+  - /data/seed.jsonl
+"#;
+
+        let source: SourceConfig = serde_yaml::from_str(yaml).unwrap();
+        let bp = source
+            .bootstrap_provider()
+            .and_then(|r| r.as_inline())
+            .expect("Expected inline bootstrap provider");
+        assert_eq!(bp.kind(), "scriptfile");
+        assert_eq!(bp.config["filePaths"][0], "/data/seed.jsonl");
+        // No source fields leak into a different-kind bootstrap provider.
+        assert!(bp.config.get("host").is_none());
+        assert!(bp.config.get("database").is_none());
+        assert!(bp.config.get("password").is_none());
     }
 
     #[test]

--- a/src/api/models/source.rs
+++ b/src/api/models/source.rs
@@ -18,7 +18,7 @@ use serde::de::{self, Deserializer, MapAccess, Visitor};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-use super::bootstrap::BootstrapProviderConfig;
+use super::bootstrap::{BootstrapProviderConfig, BootstrapProviderRef};
 
 /// Source configuration with kind discriminator.
 ///
@@ -47,7 +47,7 @@ pub struct SourceConfig {
     pub kind: String,
     pub id: String,
     pub auto_start: bool,
-    pub bootstrap_provider: Option<BootstrapProviderConfig>,
+    pub bootstrap_provider: Option<BootstrapProviderRef>,
     /// Reference (by `id`) to an entry in the top-level
     /// `identityProviders` block. When set, the resolved provider is
     /// attached to the source via `Source::set_identity_provider` after
@@ -67,7 +67,14 @@ impl Serialize for SourceConfig {
         map.serialize_entry("id", &self.id)?;
         map.serialize_entry("autoStart", &self.auto_start)?;
         if let Some(bp) = &self.bootstrap_provider {
-            map.serialize_entry("bootstrapProvider", bp)?;
+            match bp {
+                BootstrapProviderRef::Reference(id) => {
+                    map.serialize_entry("bootstrapProvider", id)?;
+                }
+                BootstrapProviderRef::Inline(config) => {
+                    map.serialize_entry("bootstrapProvider", config)?;
+                }
+            }
         }
         if let Some(ip) = &self.identity_provider {
             map.serialize_entry("identityProvider", ip)?;
@@ -172,16 +179,32 @@ impl<'de> Deserialize<'de> for SourceConfig {
 
                 let remaining_value = serde_json::Value::Object(remaining);
 
-                // Deserialize bootstrap_provider if present, inheriting from source when applicable.
-                let bootstrap_provider: Option<BootstrapProviderConfig> = bootstrap_provider
-                    .map(|value| {
-                        merge_bootstrap_provider_with_source(&kind, value, &remaining_value)
-                    })
-                    .map(serde_json::from_value)
-                    .transpose()
-                    .map_err(|e| {
-                        de::Error::custom(format!("in source '{id}' bootstrapProvider: {e}"))
-                    })?;
+                // Resolve bootstrapProvider: a string is a reference to a
+                // top-level `bootstrapProviders` entry; a mapping is an inline
+                // definition (which may inherit fields from the source).
+                let bootstrap_provider: Option<BootstrapProviderRef> = match bootstrap_provider {
+                    None => None,
+                    Some(serde_json::Value::String(id)) => {
+                        Some(BootstrapProviderRef::Reference(id))
+                    }
+                    Some(value @ serde_json::Value::Object(_)) => {
+                        let merged =
+                            merge_bootstrap_provider_with_source(&kind, value, &remaining_value);
+                        let config: BootstrapProviderConfig = serde_json::from_value(merged)
+                            .map_err(|e| {
+                                de::Error::custom(format!(
+                                    "in source '{id}' bootstrapProvider: {e}"
+                                ))
+                            })?;
+                        Some(BootstrapProviderRef::Inline(config))
+                    }
+                    Some(_) => {
+                        return Err(de::Error::custom(format!(
+                            "in source '{id}' bootstrapProvider: expected a string reference \
+                             to a top-level bootstrapProviders entry or an inline mapping"
+                        )));
+                    }
+                };
 
                 Ok(SourceConfig {
                     kind,
@@ -214,8 +237,9 @@ impl SourceConfig {
         self.auto_start = value;
     }
 
-    /// Get the bootstrap provider configuration if any
-    pub fn bootstrap_provider(&self) -> Option<&BootstrapProviderConfig> {
+    /// Get the bootstrap provider reference if any (inline definition or a
+    /// reference to a top-level `bootstrapProviders` entry).
+    pub fn bootstrap_provider(&self) -> Option<&BootstrapProviderRef> {
         self.bootstrap_provider.as_ref()
     }
 
@@ -570,7 +594,8 @@ bootstrapProvider:
         let source: SourceConfig = serde_yaml::from_str(yaml).unwrap();
         let bp = source
             .bootstrap_provider()
-            .expect("Expected bootstrap provider");
+            .and_then(|r| r.as_inline())
+            .expect("Expected inline bootstrap provider");
         assert_eq!(bp.kind(), "postgres");
 
         // After merge_bootstrap_provider_with_source, inherited fields should be present
@@ -604,7 +629,8 @@ bootstrapProvider:
         let source: SourceConfig = serde_yaml::from_str(yaml).unwrap();
         let bp = source
             .bootstrap_provider()
-            .expect("Expected bootstrap provider");
+            .and_then(|r| r.as_inline())
+            .expect("Expected inline bootstrap provider");
         assert_eq!(bp.kind(), "postgres");
 
         // Overridden fields

--- a/src/api/shared/handlers/instance_handlers.rs
+++ b/src/api/shared/handlers/instance_handlers.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use super::persist_after_operation;
-use crate::api::models::BootstrapProviderConfig;
 use crate::api::models::ConfigValue;
+use crate::api::models::{BootstrapProviderConfig, BootstrapProviderRef};
 use crate::api::shared::error::{error_codes, ErrorDetail, ErrorResponse};
 use crate::api::shared::extractor::ConfigBody;
 use crate::api::shared::responses::{ApiResponse, StatusResponse};
@@ -155,6 +155,7 @@ pub async fn create_instance(
             reactions: Vec::new(),
             queries: Vec::new(),
             identity_providers: Vec::new(),
+            bootstrap_providers: Vec::new(),
         };
         persistence.register_instance(instance_config).await;
         persist_after_operation(&Some(persistence.clone()), "creating instance").await?;
@@ -257,10 +258,11 @@ pub async fn clone_instance(
         let bootstrap_provider = src_snap.bootstrap_provider.as_ref().map(|bp| {
             let bp_config_json = serde_json::to_value(&bp.properties)
                 .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
-            BootstrapProviderConfig {
+            BootstrapProviderRef::Inline(BootstrapProviderConfig {
                 kind: bp.kind.clone(),
+                id: None,
                 config: bp_config_json,
-            }
+            })
         });
 
         let source_config = SourceConfig {

--- a/src/api/shared/handlers/instance_handlers.rs
+++ b/src/api/shared/handlers/instance_handlers.rs
@@ -260,7 +260,6 @@ pub async fn clone_instance(
                 .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
             BootstrapProviderRef::Inline(BootstrapProviderConfig {
                 kind: bp.kind.clone(),
-                id: None,
                 config: bp_config_json,
             })
         });
@@ -303,6 +302,19 @@ pub async fn clone_instance(
                 &src_snap.id,
                 rb,
             ));
+        }
+
+        // Track the cloned source's bootstrap provider so it survives the next
+        // save(). Without this the source_bootstrap_provider map has no entry
+        // and save() would fall back to the unreliable snapshot reconstruction
+        // path, silently dropping the provider (issue #105).
+        if let Some(p) = &config_persistence {
+            p.register_source_bootstrap_provider(
+                target_instance_id,
+                &src_snap.id,
+                source_config.bootstrap_provider(),
+            )
+            .await;
         }
 
         sources_created.push(src_snap.id.clone());

--- a/src/api/shared/handlers/source_handlers.rs
+++ b/src/api/shared/handlers/source_handlers.rs
@@ -129,13 +129,13 @@ pub async fn create_source_handler(
                     config.identity_provider(),
                 )
                 .await;
-                // Track a reference-form bootstrapProvider so it round-trips
-                // as a reference. Inline definitions pass `None` and are
-                // recovered from the runtime snapshot.
+                // Track the source's bootstrapProvider (inline or reference)
+                // so it round-trips through persistence — snapshot_configuration()
+                // does not reliably carry it (issue #105).
                 p.register_source_bootstrap_provider(
                     &instance_id,
                     &source_id,
-                    config.bootstrap_provider().and_then(|r| r.as_reference()),
+                    config.bootstrap_provider(),
                 )
                 .await;
             }
@@ -236,7 +236,7 @@ pub async fn upsert_source_handler(
             p.register_source_bootstrap_provider(
                 &instance_id,
                 &source_id,
-                config.bootstrap_provider().and_then(|r| r.as_reference()),
+                config.bootstrap_provider(),
             )
             .await;
         }
@@ -278,7 +278,7 @@ pub async fn upsert_source_handler(
                 p.register_source_bootstrap_provider(
                     &instance_id,
                     &source_id,
-                    config.bootstrap_provider().and_then(|r| r.as_reference()),
+                    config.bootstrap_provider(),
                 )
                 .await;
             }

--- a/src/api/shared/handlers/source_handlers.rs
+++ b/src/api/shared/handlers/source_handlers.rs
@@ -129,6 +129,15 @@ pub async fn create_source_handler(
                     config.identity_provider(),
                 )
                 .await;
+                // Track a reference-form bootstrapProvider so it round-trips
+                // as a reference. Inline definitions pass `None` and are
+                // recovered from the runtime snapshot.
+                p.register_source_bootstrap_provider(
+                    &instance_id,
+                    &source_id,
+                    config.bootstrap_provider().and_then(|r| r.as_reference()),
+                )
+                .await;
             }
 
             persist_after_operation(&config_persistence, "creating source").await?;
@@ -224,6 +233,12 @@ pub async fn upsert_source_handler(
                 config.identity_provider(),
             )
             .await;
+            p.register_source_bootstrap_provider(
+                &instance_id,
+                &source_id,
+                config.bootstrap_provider().and_then(|r| r.as_reference()),
+            )
+            .await;
         }
 
         persist_after_operation(&config_persistence, "upserting source").await?;
@@ -258,6 +273,12 @@ pub async fn upsert_source_handler(
                     &instance_id,
                     &source_id,
                     config.identity_provider(),
+                )
+                .await;
+                p.register_source_bootstrap_provider(
+                    &instance_id,
+                    &source_id,
+                    config.bootstrap_provider().and_then(|r| r.as_reference()),
                 )
                 .await;
             }
@@ -435,6 +456,8 @@ pub async fn delete_source(
         Ok(_) => {
             if let Some(p) = &config_persistence {
                 p.unregister_source_identity_provider(&instance_id, &id)
+                    .await;
+                p.unregister_source_bootstrap_provider(&instance_id, &id)
                     .await;
             }
             persist_after_operation(&config_persistence, "deleting source").await?;

--- a/src/api/shared/handlers/source_handlers.rs
+++ b/src/api/shared/handlers/source_handlers.rs
@@ -28,7 +28,7 @@ use super::{
     ComponentViewQuery, ObservabilityQuery,
 };
 use crate::api::models::{ComponentEventDto, LogMessageDto};
-use crate::api::shared::error::{error_codes, ErrorResponse};
+use crate::api::shared::error::{error_codes, ErrorDetail, ErrorResponse};
 use crate::api::shared::extractor::ConfigBody;
 use crate::api::shared::responses::{ApiResponse, ComponentListItem, StatusResponse};
 use crate::config::SourceConfig;
@@ -87,14 +87,24 @@ async fn resolve_source_bootstrap_ref(
     instance_id: &str,
     config: &SourceConfig,
 ) -> Result<SourceConfig, ErrorResponse> {
-    let mut resolved = config.clone();
     let providers = instance_registry.bootstrap_providers(instance_id).await;
     // A dangling / unknown `bootstrapProvider: <id>` reference is a client
     // configuration error, so surface it as INVALID_REQUEST (HTTP 400) rather
-    // than SOURCE_CREATE_FAILED (HTTP 500).
-    resolve_source_bootstrap_provider(&mut resolved, &providers)
-        .map_err(|e| ErrorResponse::new(error_codes::INVALID_REQUEST, e.to_string()))?;
-    Ok(resolved)
+    // than SOURCE_CREATE_FAILED (HTTP 500). The high-level message stays in
+    // `message`; the underlying resolver error goes in `technical_details`.
+    // `config` is cloned so the caller keeps the original (with the reference
+    // intact) for persistence.
+    resolve_source_bootstrap_provider(config.clone(), &providers).map_err(|e| {
+        ErrorResponse::new(
+            error_codes::INVALID_REQUEST,
+            "Source references an unknown bootstrapProvider",
+        )
+        .with_details(ErrorDetail {
+            component_type: Some("source".to_string()),
+            component_id: Some(config.id().to_string()),
+            technical_details: Some(e.to_string()),
+        })
+    })
 }
 
 /// Create a new source

--- a/src/api/shared/handlers/source_handlers.rs
+++ b/src/api/shared/handlers/source_handlers.rs
@@ -89,8 +89,11 @@ async fn resolve_source_bootstrap_ref(
 ) -> Result<SourceConfig, ErrorResponse> {
     let mut resolved = config.clone();
     let providers = instance_registry.bootstrap_providers(instance_id).await;
+    // A dangling / unknown `bootstrapProvider: <id>` reference is a client
+    // configuration error, so surface it as INVALID_REQUEST (HTTP 400) rather
+    // than SOURCE_CREATE_FAILED (HTTP 500).
     resolve_source_bootstrap_provider(&mut resolved, &providers)
-        .map_err(|e| ErrorResponse::new(error_codes::SOURCE_CREATE_FAILED, e.to_string()))?;
+        .map_err(|e| ErrorResponse::new(error_codes::INVALID_REQUEST, e.to_string()))?;
     Ok(resolved)
 }
 

--- a/src/api/shared/handlers/source_handlers.rs
+++ b/src/api/shared/handlers/source_handlers.rs
@@ -32,7 +32,8 @@ use crate::api::shared::error::{error_codes, ErrorResponse};
 use crate::api::shared::extractor::ConfigBody;
 use crate::api::shared::responses::{ApiResponse, ComponentListItem, StatusResponse};
 use crate::config::SourceConfig;
-use crate::factories::create_source_locked;
+use crate::factories::{create_source_locked, resolve_source_bootstrap_provider};
+use crate::instance_registry::InstanceRegistry;
 use crate::persistence::ConfigPersistence;
 use crate::plugin_registry::PluginRegistry;
 use drasi_lib::channels::ComponentStatus;
@@ -73,6 +74,26 @@ pub async fn list_sources(
     Ok(Json(ApiResponse::success(items)))
 }
 
+/// Resolve a source's `bootstrapProvider: <id>` reference (if any) against the
+/// instance's declared top-level bootstrap providers, returning a config whose
+/// bootstrap provider is inlined so it can be instantiated and wired live.
+///
+/// Inline definitions and sources without a bootstrap provider are returned
+/// unchanged. Returns an error when the referenced id is not declared for the
+/// instance. The caller keeps the original config (with the reference intact)
+/// for persistence so the reference — not an inlined copy — is written back.
+async fn resolve_source_bootstrap_ref(
+    instance_registry: &InstanceRegistry,
+    instance_id: &str,
+    config: &SourceConfig,
+) -> Result<SourceConfig, ErrorResponse> {
+    let mut resolved = config.clone();
+    let providers = instance_registry.bootstrap_providers(instance_id).await;
+    resolve_source_bootstrap_provider(&mut resolved, &providers)
+        .map_err(|e| ErrorResponse::new(error_codes::SOURCE_CREATE_FAILED, e.to_string()))?;
+    Ok(resolved)
+}
+
 /// Create a new source
 pub async fn create_source_handler(
     Extension(core): Extension<Arc<drasi_lib::DrasiLib>>,
@@ -80,6 +101,7 @@ pub async fn create_source_handler(
     Extension(config_persistence): Extension<Option<Arc<ConfigPersistence>>>,
     Extension(instance_id): Extension<String>,
     Extension(plugin_registry): Extension<Arc<RwLock<PluginRegistry>>>,
+    Extension(instance_registry): Extension<InstanceRegistry>,
     ConfigBody(config_json): ConfigBody<serde_json::Value>,
 ) -> Result<Json<ApiResponse<StatusResponse>>, ErrorResponse> {
     if *read_only {
@@ -100,7 +122,13 @@ pub async fn create_source_handler(
     let source_id = config.id().to_string();
     let auto_start = config.auto_start();
 
-    let (source, plugin_meta) = create_source_locked(&plugin_registry, config.clone())
+    // Resolve any top-level `bootstrapProvider: <id>` reference against this
+    // instance's declared providers so the source is wired (and bootstraps)
+    // live. The original `config` retains the reference for persistence.
+    let create_config =
+        resolve_source_bootstrap_ref(&instance_registry, &instance_id, &config).await?;
+
+    let (source, plugin_meta) = create_source_locked(&plugin_registry, create_config)
         .await
         .map_err(|e| {
             log::error!("Failed to create source instance: {e}");
@@ -171,6 +199,7 @@ pub async fn upsert_source_handler(
     Extension(config_persistence): Extension<Option<Arc<ConfigPersistence>>>,
     Extension(instance_id): Extension<String>,
     Extension(plugin_registry): Extension<Arc<RwLock<PluginRegistry>>>,
+    Extension(instance_registry): Extension<InstanceRegistry>,
     Path(path_id): Path<String>,
     ConfigBody(config_json): ConfigBody<serde_json::Value>,
 ) -> Result<Json<ApiResponse<StatusResponse>>, ErrorResponse> {
@@ -202,12 +231,17 @@ pub async fn upsert_source_handler(
     let source_id = config.id().to_string();
     let auto_start = config.auto_start();
 
+    // Resolve any top-level `bootstrapProvider: <id>` reference so the source
+    // is wired live; `config` keeps the reference for persistence.
+    let create_config =
+        resolve_source_bootstrap_ref(&instance_registry, &instance_id, &config).await?;
+
     // Check if source already exists
     let exists = core.get_source_status(&source_id).await.is_ok();
 
     if exists {
         // Create a new source instance and use update_source to replace in place
-        let (new_source, _meta) = create_source_locked(&plugin_registry, config.clone())
+        let (new_source, _meta) = create_source_locked(&plugin_registry, create_config)
             .await
             .map_err(|e| {
                 log::error!("Failed to create source instance for update: {e}");
@@ -248,7 +282,7 @@ pub async fn upsert_source_handler(
         })));
     }
 
-    let (source, plugin_meta) = create_source_locked(&plugin_registry, config.clone())
+    let (source, plugin_meta) = create_source_locked(&plugin_registry, create_config)
         .await
         .map_err(|e| {
             log::error!("Failed to create source instance: {e}");

--- a/src/api/shared/handlers/source_handlers.rs
+++ b/src/api/shared/handlers/source_handlers.rs
@@ -193,6 +193,7 @@ pub async fn create_source_handler(
 }
 
 /// Upsert a source (create or update)
+#[allow(clippy::too_many_arguments)]
 pub async fn upsert_source_handler(
     Extension(core): Extension<Arc<drasi_lib::DrasiLib>>,
     Extension(read_only): Extension<Arc<bool>>,

--- a/src/api/shared/solutions.rs
+++ b/src/api/shared/solutions.rs
@@ -327,10 +327,13 @@ pub async fn create_solution_template(
             let bootstrap_provider = source_snap.bootstrap_provider.as_ref().map(|bp| {
                 let bp_config_json = serde_json::to_value(&bp.properties)
                     .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
-                crate::api::models::BootstrapProviderConfig {
-                    kind: bp.kind.clone(),
-                    config: bp_config_json,
-                }
+                crate::api::models::BootstrapProviderRef::Inline(
+                    crate::api::models::BootstrapProviderConfig {
+                        kind: bp.kind.clone(),
+                        id: None,
+                        config: bp_config_json,
+                    },
+                )
             });
 
             let source_dto = SourceConfig {

--- a/src/api/shared/solutions.rs
+++ b/src/api/shared/solutions.rs
@@ -330,7 +330,6 @@ pub async fn create_solution_template(
                 crate::api::models::BootstrapProviderRef::Inline(
                     crate::api::models::BootstrapProviderConfig {
                         kind: bp.kind.clone(),
-                        id: None,
                         config: bp_config_json,
                     },
                 )

--- a/src/api/v1/handlers/source_handlers.rs
+++ b/src/api/v1/handlers/source_handlers.rs
@@ -111,6 +111,7 @@ pub async fn create_source_handler(
         Extension(config_persistence),
         Extension(instance_id),
         Extension(plugin_registry),
+        Extension(registry),
         ConfigBody(config_json),
     )
     .await
@@ -164,6 +165,7 @@ pub async fn upsert_source_handler(
         Extension(config_persistence),
         Extension(path.instance_id),
         Extension(plugin_registry),
+        Extension(registry),
         Path(path.id),
         ConfigBody(config_json),
     )

--- a/src/config/plugin_validation.rs
+++ b/src/config/plugin_validation.rs
@@ -162,8 +162,8 @@ pub fn extract_plugin_requirements(config: &DrasiServerConfig) -> Vec<PluginRequ
     for bp in &all_bootstrap_providers {
         requirements.push(PluginRequirement {
             category: "bootstrap".to_string(),
-            kind: bp.kind.clone(),
-            referenced_by: format!("bootstrapProvider '{}'", bp.id().unwrap_or("<missing id>")),
+            kind: bp.kind().to_string(),
+            referenced_by: format!("bootstrapProvider '{}'", bp.id()),
         });
     }
 
@@ -278,11 +278,8 @@ pub fn check_config_references(config: &DrasiServerConfig) -> Vec<ReferenceWarni
     }
 
     for bp in &all_bootstrap_providers {
-        let prefix = format!(
-            "bootstrapProviders['{}']",
-            bp.id().unwrap_or("<missing id>")
-        );
-        walk_json_env_refs(&bp.config, &prefix, &mut warnings);
+        let prefix = format!("bootstrapProviders['{}']", bp.id());
+        walk_json_env_refs(&bp.inner.config, &prefix, &mut warnings);
     }
 
     for rxn in &all_reactions {
@@ -479,7 +476,7 @@ pub(crate) fn collect_all_identity_providers(
 /// Collect all top-level bootstrap providers from config (top-level + instances).
 pub(crate) fn collect_all_bootstrap_providers(
     config: &DrasiServerConfig,
-) -> Vec<crate::api::models::BootstrapProviderConfig> {
+) -> Vec<crate::api::models::TopLevelBootstrapProviderConfig> {
     let mut providers = config.bootstrap_providers.clone();
     for inst in &config.instances {
         providers.extend(inst.bootstrap_providers.clone());
@@ -631,7 +628,6 @@ mod tests {
             identity_provider: None,
             bootstrap_provider: Some(BootstrapProviderRef::Inline(BootstrapProviderConfig {
                 kind: bp_kind.to_string(),
-                id: None,
                 config: serde_json::json!({}),
             })),
             config: serde_json::json!({}),

--- a/src/config/plugin_validation.rs
+++ b/src/config/plugin_validation.rs
@@ -139,6 +139,7 @@ pub fn extract_plugin_requirements(config: &DrasiServerConfig) -> Vec<PluginRequ
     let all_sources = collect_all_sources(config);
     let all_reactions = collect_all_reactions(config);
     let all_identity_providers = collect_all_identity_providers(config);
+    let all_bootstrap_providers = collect_all_bootstrap_providers(config);
 
     for src in &all_sources {
         requirements.push(PluginRequirement {
@@ -147,13 +148,23 @@ pub fn extract_plugin_requirements(config: &DrasiServerConfig) -> Vec<PluginRequ
             referenced_by: format!("source '{}'", src.id),
         });
 
-        if let Some(bp) = &src.bootstrap_provider {
+        if let Some(bp) = src.bootstrap_provider().and_then(|r| r.as_inline()) {
             requirements.push(PluginRequirement {
                 category: "bootstrap".to_string(),
                 kind: bp.kind.clone(),
                 referenced_by: format!("source '{}' bootstrapProvider", src.id),
             });
         }
+    }
+
+    // Top-level bootstrap providers are referenced by sources via
+    // `bootstrapProvider: <id>`. Their plugin kinds must be available too.
+    for bp in &all_bootstrap_providers {
+        requirements.push(PluginRequirement {
+            category: "bootstrap".to_string(),
+            kind: bp.kind.clone(),
+            referenced_by: format!("bootstrapProvider '{}'", bp.id().unwrap_or("<missing id>")),
+        });
     }
 
     for rxn in &all_reactions {
@@ -255,14 +266,23 @@ pub fn check_config_references(config: &DrasiServerConfig) -> Vec<ReferenceWarni
     let all_sources = collect_all_sources(config);
     let all_reactions = collect_all_reactions(config);
     let all_identity_providers = collect_all_identity_providers(config);
+    let all_bootstrap_providers = collect_all_bootstrap_providers(config);
 
     for src in &all_sources {
         let prefix = format!("sources['{}']", src.id);
         walk_json_env_refs(&src.config, &prefix, &mut warnings);
-        if let Some(bp) = &src.bootstrap_provider {
+        if let Some(bp) = src.bootstrap_provider().and_then(|r| r.as_inline()) {
             let bp_prefix = format!("{prefix}.bootstrapProvider");
             walk_json_env_refs(&bp.config, &bp_prefix, &mut warnings);
         }
+    }
+
+    for bp in &all_bootstrap_providers {
+        let prefix = format!(
+            "bootstrapProviders['{}']",
+            bp.id().unwrap_or("<missing id>")
+        );
+        walk_json_env_refs(&bp.config, &prefix, &mut warnings);
     }
 
     for rxn in &all_reactions {
@@ -456,6 +476,17 @@ pub(crate) fn collect_all_identity_providers(
     providers
 }
 
+/// Collect all top-level bootstrap providers from config (top-level + instances).
+pub(crate) fn collect_all_bootstrap_providers(
+    config: &DrasiServerConfig,
+) -> Vec<crate::api::models::BootstrapProviderConfig> {
+    let mut providers = config.bootstrap_providers.clone();
+    for inst in &config.instances {
+        providers.extend(inst.bootstrap_providers.clone());
+    }
+    providers
+}
+
 // ===========================================================================
 // Tests
 // ===========================================================================
@@ -463,7 +494,9 @@ pub(crate) fn collect_all_identity_providers(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::models::{BootstrapProviderConfig, ReactionConfig, SourceConfig};
+    use crate::api::models::{
+        BootstrapProviderConfig, BootstrapProviderRef, ReactionConfig, SourceConfig,
+    };
     use async_trait::async_trait;
     use drasi_plugin_sdk::{
         BootstrapPluginDescriptor, ReactionPluginDescriptor, SourcePluginDescriptor,
@@ -596,10 +629,11 @@ mod tests {
             id: id.to_string(),
             auto_start: true,
             identity_provider: None,
-            bootstrap_provider: Some(BootstrapProviderConfig {
+            bootstrap_provider: Some(BootstrapProviderRef::Inline(BootstrapProviderConfig {
                 kind: bp_kind.to_string(),
+                id: None,
                 config: serde_json::json!({}),
-            }),
+            })),
             config: serde_json::json!({}),
         }
     }

--- a/src/config/schema_validation.rs
+++ b/src/config/schema_validation.rs
@@ -22,8 +22,8 @@ use log::warn;
 use serde_json::Value;
 
 use super::plugin_validation::{
-    collect_all_reactions, collect_all_sources, schema_error_codes, ComponentValidationReport,
-    FieldError,
+    collect_all_bootstrap_providers, collect_all_reactions, collect_all_sources,
+    schema_error_codes, ComponentValidationReport, FieldError,
 };
 use crate::config::types::DrasiServerConfig;
 use crate::plugin_registry::PluginRegistry;
@@ -41,6 +41,7 @@ pub fn validate_component_configs(
 
     let all_sources = collect_all_sources(config);
     let all_reactions = collect_all_reactions(config);
+    let all_bootstrap_providers = collect_all_bootstrap_providers(config);
 
     for src in &all_sources {
         if let Some(descriptor) = registry.get_source(&src.kind) {
@@ -58,7 +59,7 @@ pub fn validate_component_configs(
         }
 
         // Also validate bootstrap provider config if plugin is available
-        if let Some(bp) = &src.bootstrap_provider {
+        if let Some(bp) = src.bootstrap_provider().and_then(|r| r.as_inline()) {
             if let Some(descriptor) = registry.get_bootstrapper(&bp.kind) {
                 let schema_json = descriptor.config_schema_json();
                 let schema_name = descriptor.config_schema_name().to_string();
@@ -85,6 +86,26 @@ pub fn validate_component_configs(
                     component_type: "reaction".to_string(),
                     component_id: rxn.id.clone(),
                     plugin_kind: rxn.kind.clone(),
+                    errors,
+                });
+            }
+        }
+    }
+
+    // Validate top-level bootstrap providers against their plugin schemas.
+    for bp in &all_bootstrap_providers {
+        if let Some(descriptor) = registry.get_bootstrapper(&bp.kind) {
+            let schema_json = descriptor.config_schema_json();
+            let schema_name = descriptor.config_schema_name().to_string();
+            let errors = validate_against_schema(&schema_json, &schema_name, &bp.config);
+            if !errors.is_empty() {
+                reports.push(ComponentValidationReport {
+                    component_type: "bootstrap".to_string(),
+                    component_id: format!(
+                        "bootstrapProvider '{}'",
+                        bp.id().unwrap_or("<missing id>")
+                    ),
+                    plugin_kind: bp.kind.clone(),
                     errors,
                 });
             }
@@ -237,7 +258,9 @@ fn rewrite_refs(value: &mut Value) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::models::{BootstrapProviderConfig, ReactionConfig, SourceConfig};
+    use crate::api::models::{
+        BootstrapProviderConfig, BootstrapProviderRef, ReactionConfig, SourceConfig,
+    };
     use crate::config::types::DrasiServerConfig;
     use async_trait::async_trait;
     use drasi_plugin_sdk::{
@@ -615,12 +638,13 @@ mod tests {
                 id: "pg1".to_string(),
                 auto_start: true,
                 identity_provider: None,
-                bootstrap_provider: Some(BootstrapProviderConfig {
+                bootstrap_provider: Some(BootstrapProviderRef::Inline(BootstrapProviderConfig {
                     kind: "scriptfile".to_string(),
+                    id: None,
                     config: serde_json::json!({
                         "filePaths": ["/data/file1.jsonl"]
                     }),
-                }),
+                })),
                 config: serde_json::json!({
                     "host": "localhost",
                     "database": "mydb"
@@ -642,10 +666,11 @@ mod tests {
                 id: "pg1".to_string(),
                 auto_start: true,
                 identity_provider: None,
-                bootstrap_provider: Some(BootstrapProviderConfig {
+                bootstrap_provider: Some(BootstrapProviderRef::Inline(BootstrapProviderConfig {
                     kind: "scriptfile".to_string(),
+                    id: None,
                     config: serde_json::json!({}), // missing filePaths
-                }),
+                })),
                 config: serde_json::json!({
                     "host": "localhost",
                     "database": "mydb"

--- a/src/config/schema_validation.rs
+++ b/src/config/schema_validation.rs
@@ -94,18 +94,15 @@ pub fn validate_component_configs(
 
     // Validate top-level bootstrap providers against their plugin schemas.
     for bp in &all_bootstrap_providers {
-        if let Some(descriptor) = registry.get_bootstrapper(&bp.kind) {
+        if let Some(descriptor) = registry.get_bootstrapper(bp.kind()) {
             let schema_json = descriptor.config_schema_json();
             let schema_name = descriptor.config_schema_name().to_string();
-            let errors = validate_against_schema(&schema_json, &schema_name, &bp.config);
+            let errors = validate_against_schema(&schema_json, &schema_name, &bp.inner.config);
             if !errors.is_empty() {
                 reports.push(ComponentValidationReport {
                     component_type: "bootstrap".to_string(),
-                    component_id: format!(
-                        "bootstrapProvider '{}'",
-                        bp.id().unwrap_or("<missing id>")
-                    ),
-                    plugin_kind: bp.kind.clone(),
+                    component_id: format!("bootstrapProvider '{}'", bp.id()),
+                    plugin_kind: bp.kind().to_string(),
                     errors,
                 });
             }
@@ -640,7 +637,6 @@ mod tests {
                 identity_provider: None,
                 bootstrap_provider: Some(BootstrapProviderRef::Inline(BootstrapProviderConfig {
                     kind: "scriptfile".to_string(),
-                    id: None,
                     config: serde_json::json!({
                         "filePaths": ["/data/file1.jsonl"]
                     }),
@@ -668,7 +664,6 @@ mod tests {
                 identity_provider: None,
                 bootstrap_provider: Some(BootstrapProviderRef::Inline(BootstrapProviderConfig {
                     kind: "scriptfile".to_string(),
-                    id: None,
                     config: serde_json::json!({}), // missing filePaths
                 })),
                 config: serde_json::json!({

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -23,8 +23,8 @@ use std::str::FromStr;
 // Import the config enums from api::models
 use crate::api::mappings::{DtoMapper, QueryConfigMapper};
 use crate::api::models::{
-    ConfigValue, IdentityProviderConfig, QueryConfigDto, ReactionConfig, SecretStoreConfig,
-    SourceConfig, StateStoreConfig,
+    BootstrapProviderConfig, ConfigValue, IdentityProviderConfig, QueryConfigDto, ReactionConfig,
+    SecretStoreConfig, SourceConfig, StateStoreConfig,
 };
 use drasi_lib::config::QueryConfig;
 
@@ -142,6 +142,10 @@ pub struct DrasiServerConfig {
     #[serde(default)]
     #[schema(value_type = Vec<serde_json::Value>)]
     pub identity_providers: Vec<IdentityProviderConfig>,
+    /// Bootstrap provider configurations (referenced by sources via `bootstrapProvider: <id>`)
+    #[serde(default)]
+    #[schema(value_type = Vec<serde_json::Value>)]
+    pub bootstrap_providers: Vec<BootstrapProviderConfig>,
     /// Optional list of DrasiLib instances when running in multi-tenant mode
     #[serde(default)]
     pub instances: Vec<DrasiLibInstanceConfig>,
@@ -175,6 +179,7 @@ impl Default for DrasiServerConfig {
             queries: Vec::new(),
             reactions: Vec::new(),
             identity_providers: Vec::new(),
+            bootstrap_providers: Vec::new(),
             instances: Vec::new(),
         }
     }
@@ -296,6 +301,10 @@ pub struct DrasiLibInstanceConfig {
     #[serde(default)]
     #[schema(value_type = Vec<serde_json::Value>)]
     pub identity_providers: Vec<IdentityProviderConfig>,
+    /// Bootstrap provider configurations referenced by sources via `bootstrapProvider: <id>`.
+    #[serde(default)]
+    #[schema(value_type = Vec<serde_json::Value>)]
+    pub bootstrap_providers: Vec<BootstrapProviderConfig>,
 }
 
 /// Resolved instance settings with ConfigValue evaluated
@@ -311,6 +320,7 @@ pub struct ResolvedInstanceConfig {
     pub queries: Vec<QueryConfig>,
     pub reactions: Vec<ReactionConfig>,
     pub identity_providers: Vec<IdentityProviderConfig>,
+    pub bootstrap_providers: Vec<BootstrapProviderConfig>,
 }
 
 /// Validate hostname format according to RFC 1123
@@ -365,6 +375,7 @@ impl DrasiServerConfig {
                 queries: self.queries.clone(),
                 reactions: self.reactions.clone(),
                 identity_providers: self.identity_providers.clone(),
+                bootstrap_providers: self.bootstrap_providers.clone(),
             }]
         } else {
             self.instances.clone()
@@ -404,6 +415,33 @@ impl DrasiServerConfig {
                 .map(|dto| mapper.map_with(dto, &query_mapper))
                 .collect::<Result<Vec<_>, _>>()?;
 
+            // Validate top-level bootstrap providers and any source references
+            // to them so dangling references are caught before startup.
+            let mut bootstrap_ids: HashSet<String> = HashSet::new();
+            for bp in &instance.bootstrap_providers {
+                let bp_id = bp.id().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Instance '{id}': top-level bootstrapProvider (kind '{}') is missing required 'id'",
+                        bp.kind()
+                    )
+                })?;
+                if !bootstrap_ids.insert(bp_id.to_string()) {
+                    return Err(anyhow::anyhow!(
+                        "Instance '{id}': duplicate bootstrapProvider id '{bp_id}'"
+                    ));
+                }
+            }
+            for src in &instance.sources {
+                if let Some(bp_ref) = src.bootstrap_provider().and_then(|r| r.as_reference()) {
+                    if !bootstrap_ids.contains(bp_ref) {
+                        return Err(anyhow::anyhow!(
+                            "Instance '{id}': source '{}' references unknown bootstrapProvider '{bp_ref}'",
+                            src.id()
+                        ));
+                    }
+                }
+            }
+
             resolved.push(ResolvedInstanceConfig {
                 id,
                 persist_index: instance.persist_index,
@@ -415,6 +453,7 @@ impl DrasiServerConfig {
                 queries,
                 reactions: instance.reactions.clone(),
                 identity_providers: instance.identity_providers.clone(),
+                bootstrap_providers: instance.bootstrap_providers.clone(),
             });
         }
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -23,8 +23,8 @@ use std::str::FromStr;
 // Import the config enums from api::models
 use crate::api::mappings::{DtoMapper, QueryConfigMapper};
 use crate::api::models::{
-    BootstrapProviderConfig, ConfigValue, IdentityProviderConfig, QueryConfigDto, ReactionConfig,
-    SecretStoreConfig, SourceConfig, StateStoreConfig,
+    ConfigValue, IdentityProviderConfig, QueryConfigDto, ReactionConfig, SecretStoreConfig,
+    SourceConfig, StateStoreConfig, TopLevelBootstrapProviderConfig,
 };
 use drasi_lib::config::QueryConfig;
 
@@ -142,10 +142,10 @@ pub struct DrasiServerConfig {
     #[serde(default)]
     #[schema(value_type = Vec<serde_json::Value>)]
     pub identity_providers: Vec<IdentityProviderConfig>,
-    /// Bootstrap provider configurations (referenced by sources via `bootstrapProvider: <id>`)
+    /// Top-level bootstrap provider configurations referenced by sources via `bootstrapProvider: <id>`.
     #[serde(default)]
     #[schema(value_type = Vec<serde_json::Value>)]
-    pub bootstrap_providers: Vec<BootstrapProviderConfig>,
+    pub bootstrap_providers: Vec<TopLevelBootstrapProviderConfig>,
     /// Optional list of DrasiLib instances when running in multi-tenant mode
     #[serde(default)]
     pub instances: Vec<DrasiLibInstanceConfig>,
@@ -304,7 +304,7 @@ pub struct DrasiLibInstanceConfig {
     /// Bootstrap provider configurations referenced by sources via `bootstrapProvider: <id>`.
     #[serde(default)]
     #[schema(value_type = Vec<serde_json::Value>)]
-    pub bootstrap_providers: Vec<BootstrapProviderConfig>,
+    pub bootstrap_providers: Vec<TopLevelBootstrapProviderConfig>,
 }
 
 /// Resolved instance settings with ConfigValue evaluated
@@ -320,7 +320,7 @@ pub struct ResolvedInstanceConfig {
     pub queries: Vec<QueryConfig>,
     pub reactions: Vec<ReactionConfig>,
     pub identity_providers: Vec<IdentityProviderConfig>,
-    pub bootstrap_providers: Vec<BootstrapProviderConfig>,
+    pub bootstrap_providers: Vec<TopLevelBootstrapProviderConfig>,
 }
 
 /// Validate hostname format according to RFC 1123
@@ -416,18 +416,16 @@ impl DrasiServerConfig {
                 .collect::<Result<Vec<_>, _>>()?;
 
             // Validate top-level bootstrap providers and any source references
-            // to them so dangling references are caught before startup.
+            // to them so dangling references are caught before startup. The
+            // required `id` is enforced structurally by
+            // `TopLevelBootstrapProviderConfig`, so only duplicate ids and
+            // dangling references need checking here.
             let mut bootstrap_ids: HashSet<String> = HashSet::new();
             for bp in &instance.bootstrap_providers {
-                let bp_id = bp.id().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "Instance '{id}': top-level bootstrapProvider (kind '{}') is missing required 'id'",
-                        bp.kind()
-                    )
-                })?;
-                if !bootstrap_ids.insert(bp_id.to_string()) {
+                if !bootstrap_ids.insert(bp.id().to_string()) {
                     return Err(anyhow::anyhow!(
-                        "Instance '{id}': duplicate bootstrapProvider id '{bp_id}'"
+                        "Instance '{id}': duplicate bootstrapProvider id '{}'",
+                        bp.id()
                     ));
                 }
             }

--- a/src/factories.rs
+++ b/src/factories.rs
@@ -29,7 +29,8 @@ use std::sync::Arc;
 
 use crate::api::mappings::DtoMapper;
 use crate::api::models::{
-    BootstrapProviderConfig, ConfigValue, IdentityProviderConfig, BUILTIN_PASSWORD_KIND,
+    BootstrapProviderConfig, ConfigValue, IdentityProviderConfig, TopLevelBootstrapProviderConfig,
+    BUILTIN_PASSWORD_KIND,
 };
 use crate::config::{ReactionConfig, SecretStoreConfig, SourceConfig, StateStoreConfig};
 use crate::plugin_registry::PluginRegistry;
@@ -289,40 +290,43 @@ pub async fn create_bootstrap_provider(
 /// Build a `{id -> BootstrapProviderConfig}` map from a slice of top-level
 /// bootstrap provider configs.
 ///
-/// Each entry must carry an `id`. Fails on a missing id or a duplicate id.
-/// Unlike identity providers, bootstrap provider *instances* are not built
-/// here: because `Source::set_bootstrap_provider` takes an owned value, each
-/// referencing source instantiates its own provider from the shared config at
-/// source-creation time.
+/// The `id` is guaranteed to be present by the type; this only fails on a
+/// duplicate id. Unlike identity providers, bootstrap provider *instances* are
+/// not built here: because `Source::set_bootstrap_provider` takes an owned
+/// value, each referencing source instantiates its own provider from the
+/// shared config at source-creation time.
 pub fn build_bootstrap_provider_config_map(
-    configs: &[BootstrapProviderConfig],
+    configs: &[TopLevelBootstrapProviderConfig],
 ) -> Result<HashMap<String, BootstrapProviderConfig>> {
     let mut map: HashMap<String, BootstrapProviderConfig> = HashMap::new();
     for cfg in configs {
-        let id = cfg.id().ok_or_else(|| {
-            anyhow::anyhow!(
-                "Top-level bootstrapProvider (kind '{}') is missing required 'id'",
-                cfg.kind()
-            )
-        })?;
-        if map.contains_key(id) {
-            return Err(anyhow::anyhow!("Duplicate bootstrapProvider id '{id}'"));
+        if map.contains_key(cfg.id()) {
+            return Err(anyhow::anyhow!(
+                "Duplicate bootstrapProvider id '{}'",
+                cfg.id()
+            ));
         }
-        map.insert(id.to_string(), cfg.clone());
+        map.insert(cfg.id().to_string(), cfg.inner.clone());
     }
     Ok(map)
 }
 
 /// Resolve a source's `bootstrapProvider` reference (if any) against the
-/// top-level bootstrap provider config map, rewriting it to an inline
-/// definition so the source-creation path can instantiate it.
+/// top-level bootstrap provider config map, returning a new [`SourceConfig`]
+/// whose reference has been rewritten to an inline definition so the
+/// source-creation path can instantiate it.
+///
+/// Takes the config **by value** and returns the resolved copy, so a caller
+/// that needs the original (e.g. to persist the reference rather than the
+/// inlined copy) keeps its own value explicitly — the ownership split is
+/// enforced by the compiler rather than by convention.
 ///
 /// Inline bootstrap providers and sources without a bootstrap provider are
-/// left unchanged. Returns an error if the referenced id is not declared.
+/// returned unchanged. Returns an error if the referenced id is not declared.
 pub fn resolve_source_bootstrap_provider(
-    config: &mut SourceConfig,
+    mut config: SourceConfig,
     bootstrap_providers: &HashMap<String, BootstrapProviderConfig>,
-) -> Result<()> {
+) -> Result<SourceConfig> {
     if let Some(id) = config
         .bootstrap_provider
         .as_ref()
@@ -330,16 +334,24 @@ pub fn resolve_source_bootstrap_provider(
         .map(str::to_string)
     {
         let resolved = bootstrap_providers.get(&id).cloned().ok_or_else(|| {
-            anyhow::anyhow!(
-                "Source '{}' references unknown bootstrapProvider '{id}'. Declared providers: {:?}",
+            // Do NOT enumerate the declared provider ids in the returned error:
+            // it flows into API error responses and would let a caller probe
+            // for the full set of configured providers. Log them server-side
+            // (debug only) for operator troubleshooting instead.
+            log::debug!(
+                "Unknown bootstrapProvider '{id}' referenced by source '{}'. Declared providers: {:?}",
                 config.id(),
                 bootstrap_providers.keys().collect::<Vec<_>>()
+            );
+            anyhow::anyhow!(
+                "Source '{}' references unknown bootstrapProvider '{id}'",
+                config.id(),
             )
         })?;
         config.bootstrap_provider =
             Some(crate::api::models::BootstrapProviderRef::Inline(resolved));
     }
-    Ok(())
+    Ok(config)
 }
 
 /// Create a reaction instance from a ReactionConfig using the plugin registry.
@@ -690,7 +702,6 @@ mod tests {
         let registry = test_registry();
         let bootstrap_config = BootstrapProviderConfig {
             kind: "noop".to_string(),
-            id: None,
             config: serde_json::json!({}),
         };
         let source_config_json = serde_json::json!({});
@@ -703,15 +714,19 @@ mod tests {
     #[test]
     fn test_build_bootstrap_provider_config_map() {
         let configs = vec![
-            BootstrapProviderConfig {
-                kind: "postgres".to_string(),
-                id: Some("pg".to_string()),
-                config: serde_json::json!({ "host": "db.local" }),
+            TopLevelBootstrapProviderConfig {
+                id: "pg".to_string(),
+                inner: BootstrapProviderConfig {
+                    kind: "postgres".to_string(),
+                    config: serde_json::json!({ "host": "db.local" }),
+                },
             },
-            BootstrapProviderConfig {
-                kind: "scriptfile".to_string(),
-                id: Some("seed".to_string()),
-                config: serde_json::json!({ "filePaths": ["/data/seed.jsonl"] }),
+            TopLevelBootstrapProviderConfig {
+                id: "seed".to_string(),
+                inner: BootstrapProviderConfig {
+                    kind: "scriptfile".to_string(),
+                    config: serde_json::json!({ "filePaths": ["/data/seed.jsonl"] }),
+                },
             },
         ];
         let map = build_bootstrap_provider_config_map(&configs).unwrap();
@@ -721,28 +736,21 @@ mod tests {
     }
 
     #[test]
-    fn test_build_bootstrap_provider_config_map_rejects_missing_id() {
-        let configs = vec![BootstrapProviderConfig {
-            kind: "postgres".to_string(),
-            id: None, // top-level entries require an id
-            config: serde_json::json!({}),
-        }];
-        let err = build_bootstrap_provider_config_map(&configs).unwrap_err();
-        assert!(err.to_string().contains("missing required 'id'"));
-    }
-
-    #[test]
     fn test_build_bootstrap_provider_config_map_rejects_duplicate_id() {
         let configs = vec![
-            BootstrapProviderConfig {
-                kind: "postgres".to_string(),
-                id: Some("dup".to_string()),
-                config: serde_json::json!({}),
+            TopLevelBootstrapProviderConfig {
+                id: "dup".to_string(),
+                inner: BootstrapProviderConfig {
+                    kind: "postgres".to_string(),
+                    config: serde_json::json!({}),
+                },
             },
-            BootstrapProviderConfig {
-                kind: "scriptfile".to_string(),
-                id: Some("dup".to_string()),
-                config: serde_json::json!({}),
+            TopLevelBootstrapProviderConfig {
+                id: "dup".to_string(),
+                inner: BootstrapProviderConfig {
+                    kind: "scriptfile".to_string(),
+                    config: serde_json::json!({}),
+                },
             },
         ];
         let err = build_bootstrap_provider_config_map(&configs).unwrap_err();
@@ -754,7 +762,7 @@ mod tests {
         // Guards the runtime-wiring fix ("Option A"): a source referencing a
         // top-level provider is rewritten to an inline definition so the
         // source-creation path can instantiate and wire it live.
-        let mut source = SourceConfig {
+        let source = SourceConfig {
             kind: "postgres".to_string(),
             id: "src1".to_string(),
             auto_start: true,
@@ -770,12 +778,11 @@ mod tests {
             "pg-bootstrap".to_string(),
             BootstrapProviderConfig {
                 kind: "postgres".to_string(),
-                id: Some("pg-bootstrap".to_string()),
                 config: serde_json::json!({ "host": "db.local", "tables": ["Message"] }),
             },
         );
 
-        resolve_source_bootstrap_provider(&mut source, &providers).unwrap();
+        let source = resolve_source_bootstrap_provider(source, &providers).unwrap();
 
         let inline = source
             .bootstrap_provider()
@@ -787,7 +794,7 @@ mod tests {
 
     #[test]
     fn test_resolve_source_bootstrap_provider_unknown_reference_errors() {
-        let mut source = SourceConfig {
+        let source = SourceConfig {
             kind: "postgres".to_string(),
             id: "src1".to_string(),
             auto_start: true,
@@ -798,7 +805,7 @@ mod tests {
             config: serde_json::json!({}),
         };
 
-        let err = resolve_source_bootstrap_provider(&mut source, &HashMap::new()).unwrap_err();
+        let err = resolve_source_bootstrap_provider(source, &HashMap::new()).unwrap_err();
         assert!(err
             .to_string()
             .contains("references unknown bootstrapProvider 'does-not-exist'"));
@@ -807,14 +814,13 @@ mod tests {
     #[test]
     fn test_resolve_source_bootstrap_provider_inline_untouched() {
         // Inline providers (and sources without one) are left unchanged.
-        let mut source = SourceConfig {
+        let source = SourceConfig {
             kind: "postgres".to_string(),
             id: "src1".to_string(),
             auto_start: true,
             bootstrap_provider: Some(crate::api::models::BootstrapProviderRef::Inline(
                 BootstrapProviderConfig {
                     kind: "postgres".to_string(),
-                    id: None,
                     config: serde_json::json!({ "host": "inline.local" }),
                 },
             )),
@@ -822,7 +828,7 @@ mod tests {
             config: serde_json::json!({}),
         };
 
-        resolve_source_bootstrap_provider(&mut source, &HashMap::new()).unwrap();
+        let source = resolve_source_bootstrap_provider(source, &HashMap::new()).unwrap();
 
         let inline = source
             .bootstrap_provider()

--- a/src/factories.rs
+++ b/src/factories.rs
@@ -171,7 +171,11 @@ pub async fn create_source(
         )
     })?;
 
-    let bootstrap_descriptor = if let Some(bootstrap_config) = &config.bootstrap_provider {
+    let bootstrap_descriptor = if let Some(bootstrap_config) = config
+        .bootstrap_provider
+        .as_ref()
+        .and_then(|r| r.as_inline())
+    {
         let kind = bootstrap_config.kind();
         Some(registry.get_bootstrapper(kind).cloned().ok_or_else(|| {
             anyhow::anyhow!(
@@ -189,9 +193,13 @@ pub async fn create_source(
         .create_source(&config.id, &config.config, config.auto_start)
         .await?;
 
-    if let (Some(bootstrap_config), Some(bp_descriptor)) =
-        (&config.bootstrap_provider, bootstrap_descriptor)
-    {
+    if let (Some(bootstrap_config), Some(bp_descriptor)) = (
+        config
+            .bootstrap_provider
+            .as_ref()
+            .and_then(|r| r.as_inline()),
+        bootstrap_descriptor,
+    ) {
         let provider = bp_descriptor
             .create_bootstrap_provider(&bootstrap_config.config, &config.config)
             .await?;
@@ -217,7 +225,11 @@ pub async fn create_source_locked(
                 reg.source_kinds()
             )
         })?;
-        let bp_desc = if let Some(bp_config) = &config.bootstrap_provider {
+        let bp_desc = if let Some(bp_config) = config
+            .bootstrap_provider
+            .as_ref()
+            .and_then(|r| r.as_inline())
+        {
             let kind = bp_config.kind();
             Some(reg.get_bootstrapper(kind).cloned().ok_or_else(|| {
                 anyhow::anyhow!(
@@ -237,9 +249,13 @@ pub async fn create_source_locked(
         .create_source(&config.id, &config.config, config.auto_start)
         .await?;
 
-    if let (Some(bootstrap_config), Some(bp_descriptor)) =
-        (&config.bootstrap_provider, bootstrap_descriptor)
-    {
+    if let (Some(bootstrap_config), Some(bp_descriptor)) = (
+        config
+            .bootstrap_provider
+            .as_ref()
+            .and_then(|r| r.as_inline()),
+        bootstrap_descriptor,
+    ) {
         let provider = bp_descriptor
             .create_bootstrap_provider(&bootstrap_config.config, &config.config)
             .await?;
@@ -268,6 +284,62 @@ pub async fn create_bootstrap_provider(
     descriptor
         .create_bootstrap_provider(&bootstrap_config.config, source_config_json)
         .await
+}
+
+/// Build a `{id -> BootstrapProviderConfig}` map from a slice of top-level
+/// bootstrap provider configs.
+///
+/// Each entry must carry an `id`. Fails on a missing id or a duplicate id.
+/// Unlike identity providers, bootstrap provider *instances* are not built
+/// here: because `Source::set_bootstrap_provider` takes an owned value, each
+/// referencing source instantiates its own provider from the shared config at
+/// source-creation time.
+pub fn build_bootstrap_provider_config_map(
+    configs: &[BootstrapProviderConfig],
+) -> Result<HashMap<String, BootstrapProviderConfig>> {
+    let mut map: HashMap<String, BootstrapProviderConfig> = HashMap::new();
+    for cfg in configs {
+        let id = cfg.id().ok_or_else(|| {
+            anyhow::anyhow!(
+                "Top-level bootstrapProvider (kind '{}') is missing required 'id'",
+                cfg.kind()
+            )
+        })?;
+        if map.contains_key(id) {
+            return Err(anyhow::anyhow!("Duplicate bootstrapProvider id '{id}'"));
+        }
+        map.insert(id.to_string(), cfg.clone());
+    }
+    Ok(map)
+}
+
+/// Resolve a source's `bootstrapProvider` reference (if any) against the
+/// top-level bootstrap provider config map, rewriting it to an inline
+/// definition so the source-creation path can instantiate it.
+///
+/// Inline bootstrap providers and sources without a bootstrap provider are
+/// left unchanged. Returns an error if the referenced id is not declared.
+pub fn resolve_source_bootstrap_provider(
+    config: &mut SourceConfig,
+    bootstrap_providers: &HashMap<String, BootstrapProviderConfig>,
+) -> Result<()> {
+    if let Some(id) = config
+        .bootstrap_provider
+        .as_ref()
+        .and_then(|r| r.as_reference())
+        .map(str::to_string)
+    {
+        let resolved = bootstrap_providers.get(&id).cloned().ok_or_else(|| {
+            anyhow::anyhow!(
+                "Source '{}' references unknown bootstrapProvider '{id}'. Declared providers: {:?}",
+                config.id(),
+                bootstrap_providers.keys().collect::<Vec<_>>()
+            )
+        })?;
+        config.bootstrap_provider =
+            Some(crate::api::models::BootstrapProviderRef::Inline(resolved));
+    }
+    Ok(())
 }
 
 /// Create a reaction instance from a ReactionConfig using the plugin registry.
@@ -618,6 +690,7 @@ mod tests {
         let registry = test_registry();
         let bootstrap_config = BootstrapProviderConfig {
             kind: "noop".to_string(),
+            id: None,
             config: serde_json::json!({}),
         };
         let source_config_json = serde_json::json!({});

--- a/src/factories.rs
+++ b/src/factories.rs
@@ -700,6 +700,137 @@ mod tests {
         assert!(result.is_ok(), "Failed to create noop bootstrap provider");
     }
 
+    #[test]
+    fn test_build_bootstrap_provider_config_map() {
+        let configs = vec![
+            BootstrapProviderConfig {
+                kind: "postgres".to_string(),
+                id: Some("pg".to_string()),
+                config: serde_json::json!({ "host": "db.local" }),
+            },
+            BootstrapProviderConfig {
+                kind: "scriptfile".to_string(),
+                id: Some("seed".to_string()),
+                config: serde_json::json!({ "filePaths": ["/data/seed.jsonl"] }),
+            },
+        ];
+        let map = build_bootstrap_provider_config_map(&configs).unwrap();
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.get("pg").unwrap().kind(), "postgres");
+        assert_eq!(map.get("seed").unwrap().kind(), "scriptfile");
+    }
+
+    #[test]
+    fn test_build_bootstrap_provider_config_map_rejects_missing_id() {
+        let configs = vec![BootstrapProviderConfig {
+            kind: "postgres".to_string(),
+            id: None, // top-level entries require an id
+            config: serde_json::json!({}),
+        }];
+        let err = build_bootstrap_provider_config_map(&configs).unwrap_err();
+        assert!(err.to_string().contains("missing required 'id'"));
+    }
+
+    #[test]
+    fn test_build_bootstrap_provider_config_map_rejects_duplicate_id() {
+        let configs = vec![
+            BootstrapProviderConfig {
+                kind: "postgres".to_string(),
+                id: Some("dup".to_string()),
+                config: serde_json::json!({}),
+            },
+            BootstrapProviderConfig {
+                kind: "scriptfile".to_string(),
+                id: Some("dup".to_string()),
+                config: serde_json::json!({}),
+            },
+        ];
+        let err = build_bootstrap_provider_config_map(&configs).unwrap_err();
+        assert!(err.to_string().contains("Duplicate bootstrapProvider id"));
+    }
+
+    #[test]
+    fn test_resolve_source_bootstrap_provider_reference_to_inline() {
+        // Guards the runtime-wiring fix ("Option A"): a source referencing a
+        // top-level provider is rewritten to an inline definition so the
+        // source-creation path can instantiate and wire it live.
+        let mut source = SourceConfig {
+            kind: "postgres".to_string(),
+            id: "src1".to_string(),
+            auto_start: true,
+            bootstrap_provider: Some(crate::api::models::BootstrapProviderRef::Reference(
+                "pg-bootstrap".to_string(),
+            )),
+            identity_provider: None,
+            config: serde_json::json!({}),
+        };
+
+        let mut providers = HashMap::new();
+        providers.insert(
+            "pg-bootstrap".to_string(),
+            BootstrapProviderConfig {
+                kind: "postgres".to_string(),
+                id: Some("pg-bootstrap".to_string()),
+                config: serde_json::json!({ "host": "db.local", "tables": ["Message"] }),
+            },
+        );
+
+        resolve_source_bootstrap_provider(&mut source, &providers).unwrap();
+
+        let inline = source
+            .bootstrap_provider()
+            .and_then(|r| r.as_inline())
+            .expect("reference should be resolved to an inline provider");
+        assert_eq!(inline.kind(), "postgres");
+        assert_eq!(inline.config["host"], "db.local");
+    }
+
+    #[test]
+    fn test_resolve_source_bootstrap_provider_unknown_reference_errors() {
+        let mut source = SourceConfig {
+            kind: "postgres".to_string(),
+            id: "src1".to_string(),
+            auto_start: true,
+            bootstrap_provider: Some(crate::api::models::BootstrapProviderRef::Reference(
+                "does-not-exist".to_string(),
+            )),
+            identity_provider: None,
+            config: serde_json::json!({}),
+        };
+
+        let err = resolve_source_bootstrap_provider(&mut source, &HashMap::new()).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("references unknown bootstrapProvider 'does-not-exist'"));
+    }
+
+    #[test]
+    fn test_resolve_source_bootstrap_provider_inline_untouched() {
+        // Inline providers (and sources without one) are left unchanged.
+        let mut source = SourceConfig {
+            kind: "postgres".to_string(),
+            id: "src1".to_string(),
+            auto_start: true,
+            bootstrap_provider: Some(crate::api::models::BootstrapProviderRef::Inline(
+                BootstrapProviderConfig {
+                    kind: "postgres".to_string(),
+                    id: None,
+                    config: serde_json::json!({ "host": "inline.local" }),
+                },
+            )),
+            identity_provider: None,
+            config: serde_json::json!({}),
+        };
+
+        resolve_source_bootstrap_provider(&mut source, &HashMap::new()).unwrap();
+
+        let inline = source
+            .bootstrap_provider()
+            .and_then(|r| r.as_inline())
+            .unwrap();
+        assert_eq!(inline.config["host"], "inline.local");
+    }
+
     // ==========================================================================
     // Error Handling Tests
     // ==========================================================================

--- a/src/init/builder.rs
+++ b/src/init/builder.rs
@@ -91,6 +91,7 @@ pub fn build_config(
         queries,
         reactions,
         identity_providers: Vec::new(),
+        bootstrap_providers: Vec::new(),
         instances: vec![], // Empty = use single-instance mode
     }
 }

--- a/src/init/prompts.rs
+++ b/src/init/prompts.rs
@@ -20,7 +20,9 @@ use anyhow::Result;
 use inquire::{Confirm, MultiSelect, Password, Select, Text};
 
 use drasi_server::api::models::StateStoreConfig;
-use drasi_server::api::models::{BootstrapProviderConfig, ReactionConfig, SourceConfig};
+use drasi_server::api::models::{
+    BootstrapProviderConfig, BootstrapProviderRef, ReactionConfig, SourceConfig,
+};
 use drasi_server::plugin_operations::PluginOperations;
 
 /// Print a dim-colored description line before a prompt, with a blank line separator.
@@ -294,7 +296,7 @@ fn prompt_postgres_source() -> Result<SourceConfig> {
         kind: "postgres".to_string(),
         id,
         auto_start: true,
-        bootstrap_provider,
+        bootstrap_provider: bootstrap_provider.map(BootstrapProviderRef::Inline),
         identity_provider: None,
         config: serde_json::json!({
             "host": host,
@@ -337,6 +339,7 @@ fn prompt_bootstrap_provider_for_postgres(
         BootstrapType::None => Ok(None),
         BootstrapType::Postgres => Ok(Some(BootstrapProviderConfig {
             kind: "postgres".to_string(),
+            id: None,
             config: serde_json::json!({
                 "host": host,
                 "port": port,
@@ -433,7 +436,7 @@ fn prompt_http_source() -> Result<SourceConfig> {
         kind: "http".to_string(),
         id,
         auto_start: true,
-        bootstrap_provider,
+        bootstrap_provider: bootstrap_provider.map(BootstrapProviderRef::Inline),
         identity_provider: None,
         config: serde_json::json!({
             "host": host,
@@ -465,7 +468,7 @@ fn prompt_grpc_source() -> Result<SourceConfig> {
         kind: "grpc".to_string(),
         id,
         auto_start: true,
-        bootstrap_provider,
+        bootstrap_provider: bootstrap_provider.map(BootstrapProviderRef::Inline),
         identity_provider: None,
         config: serde_json::json!({
             "host": host,
@@ -547,6 +550,7 @@ fn prompt_scriptfile_bootstrap() -> Result<Option<BootstrapProviderConfig>> {
 
     Ok(Some(BootstrapProviderConfig {
         kind: "scriptfile".to_string(),
+        id: None,
         config: serde_json::json!({
             "filePaths": [file_path]
         }),
@@ -841,7 +845,7 @@ fn prompt_generic_source(kind: &str) -> Result<SourceConfig> {
         id,
         auto_start: true,
         identity_provider: None,
-        bootstrap_provider,
+        bootstrap_provider: bootstrap_provider.map(BootstrapProviderRef::Inline),
         config,
     })
 }
@@ -873,6 +877,7 @@ pub fn attach_bootstrap_to_source(
 
             Some(BootstrapProviderConfig {
                 kind: "postgres".to_string(),
+                id: None,
                 config: serde_json::json!({
                     "host": host,
                     "port": port,
@@ -893,11 +898,12 @@ pub fn attach_bootstrap_to_source(
                 serde_json::from_str(&config_json).unwrap_or_else(|_| serde_json::json!({}));
             Some(BootstrapProviderConfig {
                 kind: bootstrap_kind.to_string(),
+                id: None,
                 config,
             })
         }
     };
-    source.bootstrap_provider = bootstrap;
+    source.bootstrap_provider = bootstrap.map(BootstrapProviderRef::Inline);
     Ok(source)
 }
 

--- a/src/init/prompts.rs
+++ b/src/init/prompts.rs
@@ -339,7 +339,6 @@ fn prompt_bootstrap_provider_for_postgres(
         BootstrapType::None => Ok(None),
         BootstrapType::Postgres => Ok(Some(BootstrapProviderConfig {
             kind: "postgres".to_string(),
-            id: None,
             config: serde_json::json!({
                 "host": host,
                 "port": port,
@@ -550,7 +549,6 @@ fn prompt_scriptfile_bootstrap() -> Result<Option<BootstrapProviderConfig>> {
 
     Ok(Some(BootstrapProviderConfig {
         kind: "scriptfile".to_string(),
-        id: None,
         config: serde_json::json!({
             "filePaths": [file_path]
         }),
@@ -877,7 +875,6 @@ pub fn attach_bootstrap_to_source(
 
             Some(BootstrapProviderConfig {
                 kind: "postgres".to_string(),
-                id: None,
                 config: serde_json::json!({
                     "host": host,
                     "port": port,
@@ -898,7 +895,6 @@ pub fn attach_bootstrap_to_source(
                 serde_json::from_str(&config_json).unwrap_or_else(|_| serde_json::json!({}));
             Some(BootstrapProviderConfig {
                 kind: bootstrap_kind.to_string(),
-                id: None,
                 config,
             })
         }

--- a/src/instance_registry.rs
+++ b/src/instance_registry.rs
@@ -18,10 +18,13 @@
 //! allowing dynamic creation and deletion of instances at runtime.
 
 use indexmap::IndexMap;
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use drasi_lib::DrasiLib;
+
+use crate::api::models::BootstrapProviderConfig;
 
 /// Thread-safe registry for managing DrasiLib instances.
 ///
@@ -29,6 +32,13 @@ use drasi_lib::DrasiLib;
 #[derive(Clone)]
 pub struct InstanceRegistry {
     instances: Arc<RwLock<IndexMap<String, Arc<DrasiLib>>>>,
+    /// Per-instance top-level bootstrap provider configs, keyed by
+    /// `instance_id` then by bootstrap provider `id`. Populated at startup
+    /// from each instance's `bootstrapProviders`. Consulted by the source
+    /// create/upsert handlers so a source created at runtime that references
+    /// a top-level bootstrap provider (`bootstrapProvider: <id>`) can be
+    /// resolved and wired live.
+    bootstrap_providers: Arc<RwLock<IndexMap<String, HashMap<String, BootstrapProviderConfig>>>>,
 }
 
 impl InstanceRegistry {
@@ -36,6 +46,7 @@ impl InstanceRegistry {
     pub fn new() -> Self {
         Self {
             instances: Arc::new(RwLock::new(IndexMap::new())),
+            bootstrap_providers: Arc::new(RwLock::new(IndexMap::new())),
         }
     }
 
@@ -43,6 +54,7 @@ impl InstanceRegistry {
     pub fn from_map(instances: IndexMap<String, Arc<DrasiLib>>) -> Self {
         Self {
             instances: Arc::new(RwLock::new(instances)),
+            bootstrap_providers: Arc::new(RwLock::new(IndexMap::new())),
         }
     }
 
@@ -109,6 +121,31 @@ impl InstanceRegistry {
     pub async fn is_empty(&self) -> bool {
         let instances = self.instances.read().await;
         instances.is_empty()
+    }
+
+    /// Record the top-level bootstrap provider configs for an instance.
+    ///
+    /// Keyed by bootstrap provider `id`. Overwrites any existing entry for
+    /// the instance. Called at startup once the instance's configured
+    /// `bootstrapProviders` have been collected.
+    pub async fn set_bootstrap_providers(
+        &self,
+        instance_id: String,
+        providers: HashMap<String, BootstrapProviderConfig>,
+    ) {
+        let mut map = self.bootstrap_providers.write().await;
+        map.insert(instance_id, providers);
+    }
+
+    /// Get the top-level bootstrap provider configs for an instance (keyed by
+    /// provider `id`). Returns an empty map when the instance declared none
+    /// (including dynamically created instances).
+    pub async fn bootstrap_providers(
+        &self,
+        instance_id: &str,
+    ) -> HashMap<String, BootstrapProviderConfig> {
+        let map = self.bootstrap_providers.read().await;
+        map.get(instance_id).cloned().unwrap_or_default()
     }
 }
 

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::api::models::bootstrap::{BootstrapProviderConfig, BootstrapProviderRef};
+use crate::api::models::bootstrap::{
+    BootstrapProviderConfig, BootstrapProviderRef, TopLevelBootstrapProviderConfig,
+};
 use crate::api::models::{ConfigValue, IdentityProviderConfig, QueryConfigDto};
 use crate::config::{
     DrasiLibInstanceConfig, DrasiServerConfig, PluginDependency, ReactionConfig, SourceConfig,
@@ -59,10 +61,10 @@ struct PreservedServerSettings {
     /// (they have no runtime ComponentGraph representation) so they cannot be
     /// recovered from `snapshot_configuration()`. They must be preserved here
     /// and re-emitted by `save()`.
-    bootstrap_providers: Vec<BootstrapProviderConfig>,
+    bootstrap_providers: Vec<TopLevelBootstrapProviderConfig>,
     /// Per-instance `bootstrapProviders` keyed by instance id, captured from
     /// the original multi-instance config. See `identity_providers_by_instance`.
-    bootstrap_providers_by_instance: IndexMap<String, Vec<BootstrapProviderConfig>>,
+    bootstrap_providers_by_instance: IndexMap<String, Vec<TopLevelBootstrapProviderConfig>>,
 }
 
 /// Snapshot-based persistence for DrasiServerConfig.
@@ -247,7 +249,7 @@ impl ConfigPersistence {
                 // top-level single-instance block under the top-level instance
                 // id. Mirrors `identity_providers_by_instance`.
                 bootstrap_providers_by_instance: {
-                    let mut by_instance: IndexMap<String, Vec<BootstrapProviderConfig>> =
+                    let mut by_instance: IndexMap<String, Vec<TopLevelBootstrapProviderConfig>> =
                         original_config
                             .instances
                             .iter()
@@ -470,7 +472,6 @@ impl ConfigPersistence {
                                     }
                                     BootstrapProviderRef::Inline(BootstrapProviderConfig {
                                         kind: bp.kind.clone(),
-                                        id: None,
                                         config: serde_json::Value::Object(bp_config),
                                     })
                                 })
@@ -1041,7 +1042,6 @@ mod tests {
                 identity_provider: None,
                 bootstrap_provider: Some(BootstrapProviderRef::Inline(BootstrapProviderConfig {
                     kind: "postgres".to_string(),
-                    id: None,
                     config: serde_json::json!({ "host": "db.local", "tables": ["Message"] }),
                 })),
                 config: serde_json::json!({ "host": "db.local" }),
@@ -1082,10 +1082,12 @@ mod tests {
         let original = DrasiServerConfig {
             id: ConfigValue::Static("inst1".to_string()),
             persist_config: true,
-            bootstrap_providers: vec![BootstrapProviderConfig {
-                kind: "postgres".to_string(),
-                id: Some("pg-bootstrap".to_string()),
-                config: serde_json::json!({ "host": "db.local", "tables": ["Message"] }),
+            bootstrap_providers: vec![TopLevelBootstrapProviderConfig {
+                id: "pg-bootstrap".to_string(),
+                inner: BootstrapProviderConfig {
+                    kind: "postgres".to_string(),
+                    config: serde_json::json!({ "host": "db.local", "tables": ["Message"] }),
+                },
             }],
             sources: vec![SourceConfig {
                 kind: "postgres".to_string(),

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -102,13 +102,16 @@ pub struct ConfigPersistence {
     /// Per-component `identityProvider` references for reactions, keyed by
     /// `(instance_id, reaction_id)`. See `source_identity_provider`.
     reaction_identity_provider: Arc<RwLock<IndexMap<(String, String), String>>>,
-    /// Per-component `bootstrapProvider` *references* for sources, keyed by
-    /// `(instance_id, source_id)`. Only reference-form bootstrap providers are
-    /// tracked here; inline definitions are recovered from
-    /// `snapshot_configuration()`. Without this map the first `save()` would
-    /// rewrite a `bootstrapProvider: <id>` reference as an inline block (since
-    /// the runtime source only carries the resolved inline config).
-    source_bootstrap_provider: Arc<RwLock<IndexMap<(String, String), String>>>,
+    /// Per-component `bootstrapProvider` for sources, keyed by
+    /// `(instance_id, source_id)`. Stores the full [`BootstrapProviderRef`]
+    /// (either a top-level reference or an inline definition).
+    ///
+    /// drasi-lib's `snapshot_configuration()` does not reliably carry a
+    /// source's bootstrap provider, so without this map the first `save()`
+    /// would drop both inline `bootstrapProvider:` blocks (issue #105) and
+    /// `bootstrapProvider: <id>` references. Seeded from the original config
+    /// and kept current by the source API handlers.
+    source_bootstrap_provider: Arc<RwLock<IndexMap<(String, String), BootstrapProviderRef>>>,
 }
 
 impl ConfigPersistence {
@@ -144,7 +147,7 @@ impl ConfigPersistence {
             IndexMap::new();
         let mut reaction_identity_provider_by_instance: IndexMap<(String, String), String> =
             IndexMap::new();
-        let mut source_bootstrap_provider_by_instance: IndexMap<(String, String), String> =
+        let mut source_bootstrap_provider_by_instance: IndexMap<(String, String), BootstrapProviderRef> =
             IndexMap::new();
 
         if let Some(inst_id) = &top_level_instance_id {
@@ -153,9 +156,9 @@ impl ConfigPersistence {
                     source_identity_provider_by_instance
                         .insert((inst_id.clone(), src.id.clone()), ip.to_string());
                 }
-                if let Some(bp_ref) = src.bootstrap_provider().and_then(|r| r.as_reference()) {
+                if let Some(bp) = src.bootstrap_provider() {
                     source_bootstrap_provider_by_instance
-                        .insert((inst_id.clone(), src.id.clone()), bp_ref.to_string());
+                        .insert((inst_id.clone(), src.id.clone()), bp.clone());
                 }
             }
             for r in &original_config.reactions {
@@ -175,9 +178,9 @@ impl ConfigPersistence {
                     source_identity_provider_by_instance
                         .insert((inst_id.clone(), src.id.clone()), ip.to_string());
                 }
-                if let Some(bp_ref) = src.bootstrap_provider().and_then(|r| r.as_reference()) {
+                if let Some(bp) = src.bootstrap_provider() {
                     source_bootstrap_provider_by_instance
-                        .insert((inst_id.clone(), src.id.clone()), bp_ref.to_string());
+                        .insert((inst_id.clone(), src.id.clone()), bp.clone());
                 }
             }
             for r in &inst.reactions {
@@ -349,19 +352,18 @@ impl ConfigPersistence {
         map.shift_remove(&(instance_id.to_string(), reaction_id.to_string()));
     }
 
-    /// Register a reference-form `bootstrapProvider` for a source so it
-    /// round-trips through `save()`.
+    /// Track a source's `bootstrapProvider` so it round-trips through `save()`.
     ///
-    /// `bootstrap_provider` should be the referenced top-level id (i.e. the
-    /// value of a string-form `bootstrapProvider`). Inline bootstrap providers
-    /// must pass `None` here — they are recovered from
-    /// `snapshot_configuration()`. A `None` value removes any existing entry.
-    /// No-op when persistence is disabled.
+    /// Accepts the full [`BootstrapProviderRef`] — either a top-level reference
+    /// or an inline definition — because drasi-lib's `snapshot_configuration()`
+    /// does not reliably carry it (this is what caused issue #105 for inline
+    /// providers). A `None` value removes any existing entry. No-op when
+    /// persistence is disabled.
     pub async fn register_source_bootstrap_provider(
         &self,
         instance_id: &str,
         source_id: &str,
-        bootstrap_provider: Option<&str>,
+        bootstrap_provider: Option<&BootstrapProviderRef>,
     ) {
         if !self.persist_config {
             return;
@@ -369,10 +371,7 @@ impl ConfigPersistence {
         let mut map = self.source_bootstrap_provider.write().await;
         match bootstrap_provider {
             Some(bp) => {
-                map.insert(
-                    (instance_id.to_string(), source_id.to_string()),
-                    bp.to_string(),
-                );
+                map.insert((instance_id.to_string(), source_id.to_string()), bp.clone());
             }
             None => {
                 map.shift_remove(&(instance_id.to_string(), source_id.to_string()));
@@ -453,16 +452,14 @@ impl ConfigPersistence {
                         identity_provider: source_identity_provider
                             .get(&(id.clone(), s.id.clone()))
                             .cloned(),
-                        // Prefer a tracked reference-form bootstrapProvider so a
-                        // `bootstrapProvider: <id>` reference round-trips as a
-                        // reference rather than being rewritten inline. Fall
-                        // back to reconstructing the inline form from the
-                        // runtime snapshot (this also fixes the historical
-                        // drop of inline bootstrap providers on persist).
+                        // Prefer the tracked bootstrapProvider (inline or
+                        // reference) so it round-trips faithfully. Fall back to
+                        // reconstructing an inline form from the runtime
+                        // snapshot only if nothing was tracked (e.g. a source
+                        // whose provider was attached out-of-band).
                         bootstrap_provider: source_bootstrap_provider
                             .get(&(id.clone(), s.id.clone()))
                             .cloned()
-                            .map(BootstrapProviderRef::Reference)
                             .or_else(|| {
                                 s.bootstrap_provider.as_ref().map(|bp| {
                                     let mut bp_config = serde_json::Map::new();

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::api::models::bootstrap::BootstrapProviderConfig;
+use crate::api::models::bootstrap::{BootstrapProviderConfig, BootstrapProviderRef};
 use crate::api::models::{ConfigValue, IdentityProviderConfig, QueryConfigDto};
 use crate::config::{
     DrasiLibInstanceConfig, DrasiServerConfig, PluginDependency, ReactionConfig, SourceConfig,
@@ -53,6 +53,16 @@ struct PreservedServerSettings {
     /// instance that was declared statically rather than created dynamically
     /// via `register_instance`.
     identity_providers_by_instance: IndexMap<String, Vec<IdentityProviderConfig>>,
+    /// Top-level `bootstrapProviders` from the original single-instance config.
+    ///
+    /// Like identity providers, top-level bootstrap providers are config-only
+    /// (they have no runtime ComponentGraph representation) so they cannot be
+    /// recovered from `snapshot_configuration()`. They must be preserved here
+    /// and re-emitted by `save()`.
+    bootstrap_providers: Vec<BootstrapProviderConfig>,
+    /// Per-instance `bootstrapProviders` keyed by instance id, captured from
+    /// the original multi-instance config. See `identity_providers_by_instance`.
+    bootstrap_providers_by_instance: IndexMap<String, Vec<BootstrapProviderConfig>>,
 }
 
 /// Snapshot-based persistence for DrasiServerConfig.
@@ -92,6 +102,13 @@ pub struct ConfigPersistence {
     /// Per-component `identityProvider` references for reactions, keyed by
     /// `(instance_id, reaction_id)`. See `source_identity_provider`.
     reaction_identity_provider: Arc<RwLock<IndexMap<(String, String), String>>>,
+    /// Per-component `bootstrapProvider` *references* for sources, keyed by
+    /// `(instance_id, source_id)`. Only reference-form bootstrap providers are
+    /// tracked here; inline definitions are recovered from
+    /// `snapshot_configuration()`. Without this map the first `save()` would
+    /// rewrite a `bootstrapProvider: <id>` reference as an inline block (since
+    /// the runtime source only carries the resolved inline config).
+    source_bootstrap_provider: Arc<RwLock<IndexMap<(String, String), String>>>,
 }
 
 impl ConfigPersistence {
@@ -127,12 +144,18 @@ impl ConfigPersistence {
             IndexMap::new();
         let mut reaction_identity_provider_by_instance: IndexMap<(String, String), String> =
             IndexMap::new();
+        let mut source_bootstrap_provider_by_instance: IndexMap<(String, String), String> =
+            IndexMap::new();
 
         if let Some(inst_id) = &top_level_instance_id {
             for src in &original_config.sources {
                 if let Some(ip) = src.identity_provider() {
                     source_identity_provider_by_instance
                         .insert((inst_id.clone(), src.id.clone()), ip.to_string());
+                }
+                if let Some(bp_ref) = src.bootstrap_provider().and_then(|r| r.as_reference()) {
+                    source_bootstrap_provider_by_instance
+                        .insert((inst_id.clone(), src.id.clone()), bp_ref.to_string());
                 }
             }
             for r in &original_config.reactions {
@@ -151,6 +174,10 @@ impl ConfigPersistence {
                 if let Some(ip) = src.identity_provider() {
                     source_identity_provider_by_instance
                         .insert((inst_id.clone(), src.id.clone()), ip.to_string());
+                }
+                if let Some(bp_ref) = src.bootstrap_provider().and_then(|r| r.as_reference()) {
+                    source_bootstrap_provider_by_instance
+                        .insert((inst_id.clone(), src.id.clone()), bp_ref.to_string());
                 }
             }
             for r in &inst.reactions {
@@ -209,12 +236,39 @@ impl ConfigPersistence {
                     }
                     by_instance
                 },
+                bootstrap_providers: original_config.bootstrap_providers.clone(),
+                // Seed per-instance bootstrap providers from the original config
+                // so they survive a save in multi-instance format, folding the
+                // top-level single-instance block under the top-level instance
+                // id. Mirrors `identity_providers_by_instance`.
+                bootstrap_providers_by_instance: {
+                    let mut by_instance: IndexMap<String, Vec<BootstrapProviderConfig>> =
+                        original_config
+                            .instances
+                            .iter()
+                            .filter_map(|inst| match &inst.id {
+                                ConfigValue::Static(id) if !inst.bootstrap_providers.is_empty() => {
+                                    Some((id.clone(), inst.bootstrap_providers.clone()))
+                                }
+                                _ => None,
+                            })
+                            .collect();
+                    if !original_config.bootstrap_providers.is_empty() {
+                        if let Some(inst_id) = &top_level_instance_id {
+                            by_instance
+                                .entry(inst_id.clone())
+                                .or_insert_with(|| original_config.bootstrap_providers.clone());
+                        }
+                    }
+                    by_instance
+                },
             },
             instance_configs: Arc::new(RwLock::new(IndexMap::new())),
             source_identity_provider: Arc::new(RwLock::new(source_identity_provider_by_instance)),
             reaction_identity_provider: Arc::new(RwLock::new(
                 reaction_identity_provider_by_instance,
             )),
+            source_bootstrap_provider: Arc::new(RwLock::new(source_bootstrap_provider_by_instance)),
         }
     }
 
@@ -295,6 +349,47 @@ impl ConfigPersistence {
         map.shift_remove(&(instance_id.to_string(), reaction_id.to_string()));
     }
 
+    /// Register a reference-form `bootstrapProvider` for a source so it
+    /// round-trips through `save()`.
+    ///
+    /// `bootstrap_provider` should be the referenced top-level id (i.e. the
+    /// value of a string-form `bootstrapProvider`). Inline bootstrap providers
+    /// must pass `None` here — they are recovered from
+    /// `snapshot_configuration()`. A `None` value removes any existing entry.
+    /// No-op when persistence is disabled.
+    pub async fn register_source_bootstrap_provider(
+        &self,
+        instance_id: &str,
+        source_id: &str,
+        bootstrap_provider: Option<&str>,
+    ) {
+        if !self.persist_config {
+            return;
+        }
+        let mut map = self.source_bootstrap_provider.write().await;
+        match bootstrap_provider {
+            Some(bp) => {
+                map.insert(
+                    (instance_id.to_string(), source_id.to_string()),
+                    bp.to_string(),
+                );
+            }
+            None => {
+                map.shift_remove(&(instance_id.to_string(), source_id.to_string()));
+            }
+        }
+    }
+
+    /// Remove any preserved `bootstrapProvider` reference for a source.
+    /// Called by the source delete handler.
+    pub async fn unregister_source_bootstrap_provider(&self, instance_id: &str, source_id: &str) {
+        if !self.persist_config {
+            return;
+        }
+        let mut map = self.source_bootstrap_provider.write().await;
+        map.shift_remove(&(instance_id.to_string(), source_id.to_string()));
+    }
+
     /// Register a new instance config for persistence
     pub async fn register_instance(&self, config: DrasiLibInstanceConfig) {
         if !self.persist_config {
@@ -329,6 +424,7 @@ impl ConfigPersistence {
         let dynamic_instance_configs = self.instance_configs.read().await;
         let source_identity_provider = self.source_identity_provider.read().await;
         let reaction_identity_provider = self.reaction_identity_provider.read().await;
+        let source_bootstrap_provider = self.source_bootstrap_provider.read().await;
 
         let mut instance_configs = Vec::new();
 
@@ -357,16 +453,29 @@ impl ConfigPersistence {
                         identity_provider: source_identity_provider
                             .get(&(id.clone(), s.id.clone()))
                             .cloned(),
-                        bootstrap_provider: s.bootstrap_provider.as_ref().map(|bp| {
-                            let mut bp_config = serde_json::Map::new();
-                            for (k, v) in &bp.properties {
-                                bp_config.insert(k.clone(), v.clone());
-                            }
-                            BootstrapProviderConfig {
-                                kind: bp.kind.clone(),
-                                config: serde_json::Value::Object(bp_config),
-                            }
-                        }),
+                        // Prefer a tracked reference-form bootstrapProvider so a
+                        // `bootstrapProvider: <id>` reference round-trips as a
+                        // reference rather than being rewritten inline. Fall
+                        // back to reconstructing the inline form from the
+                        // runtime snapshot (this also fixes the historical
+                        // drop of inline bootstrap providers on persist).
+                        bootstrap_provider: source_bootstrap_provider
+                            .get(&(id.clone(), s.id.clone()))
+                            .cloned()
+                            .map(BootstrapProviderRef::Reference)
+                            .or_else(|| {
+                                s.bootstrap_provider.as_ref().map(|bp| {
+                                    let mut bp_config = serde_json::Map::new();
+                                    for (k, v) in &bp.properties {
+                                        bp_config.insert(k.clone(), v.clone());
+                                    }
+                                    BootstrapProviderRef::Inline(BootstrapProviderConfig {
+                                        kind: bp.kind.clone(),
+                                        id: None,
+                                        config: serde_json::Value::Object(bp_config),
+                                    })
+                                })
+                            }),
                         config: serde_json::Value::Object(config_map),
                     }
                 })
@@ -438,6 +547,15 @@ impl ConfigPersistence {
                             .cloned()
                             .unwrap_or_default()
                     },
+                    bootstrap_providers: if !dynamic_config.bootstrap_providers.is_empty() {
+                        dynamic_config.bootstrap_providers.clone()
+                    } else {
+                        self.preserved
+                            .bootstrap_providers_by_instance
+                            .get(&id)
+                            .cloned()
+                            .unwrap_or_default()
+                    },
                 }
             } else {
                 DrasiLibInstanceConfig {
@@ -453,6 +571,12 @@ impl ConfigPersistence {
                     identity_providers: self
                         .preserved
                         .identity_providers_by_instance
+                        .get(&id)
+                        .cloned()
+                        .unwrap_or_default(),
+                    bootstrap_providers: self
+                        .preserved
+                        .bootstrap_providers_by_instance
                         .get(&id)
                         .cloned()
                         .unwrap_or_default(),
@@ -473,6 +597,12 @@ impl ConfigPersistence {
                 instance.identity_providers.clone()
             } else {
                 self.preserved.identity_providers.clone()
+            };
+            // Same promotion for bootstrapProviders in single-instance format.
+            let bootstrap_providers = if !instance.bootstrap_providers.is_empty() {
+                instance.bootstrap_providers.clone()
+            } else {
+                self.preserved.bootstrap_providers.clone()
             };
             DrasiServerConfig {
                 api_version: None,
@@ -500,6 +630,7 @@ impl ConfigPersistence {
                 queries: instance.queries,
                 reactions: instance.reactions,
                 identity_providers,
+                bootstrap_providers,
                 instances: Vec::new(), // Empty = single-instance format
             }
         } else {
@@ -543,6 +674,9 @@ impl ConfigPersistence {
                 // top-level instance's `identityProviders` at construction time
                 // (see `new()`), so the top-level field stays empty here.
                 identity_providers: Vec::new(),
+                // Same as identityProviders: bootstrapProviders live per-instance
+                // in multi-instance format.
+                bootstrap_providers: Vec::new(),
                 instances: instance_configs,
             }
         };

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -147,8 +147,10 @@ impl ConfigPersistence {
             IndexMap::new();
         let mut reaction_identity_provider_by_instance: IndexMap<(String, String), String> =
             IndexMap::new();
-        let mut source_bootstrap_provider_by_instance: IndexMap<(String, String), BootstrapProviderRef> =
-            IndexMap::new();
+        let mut source_bootstrap_provider_by_instance: IndexMap<
+            (String, String),
+            BootstrapProviderRef,
+        > = IndexMap::new();
 
         if let Some(inst_id) = &top_level_instance_id {
             for src in &original_config.sources {
@@ -1018,6 +1020,111 @@ mod tests {
         assert!(ids.contains(&"src-a"));
         assert!(ids.contains(&"src-b"));
         assert!(ids.contains(&"src-c"));
+    }
+
+    #[tokio::test]
+    async fn test_save_preserves_inline_bootstrap_provider() {
+        // Regression test for #105: an inline `bootstrapProvider` must survive
+        // `save()`. It was previously dropped because it isn't recovered from
+        // `snapshot_configuration()`; it is now round-tripped via the tracked
+        // `source_bootstrap_provider` map seeded from the original config.
+        let tmp = TempDir::new().unwrap();
+        let cfg_path = tmp.path().join("server.yaml");
+
+        let original = DrasiServerConfig {
+            id: ConfigValue::Static("inst1".to_string()),
+            persist_config: true,
+            sources: vec![SourceConfig {
+                kind: "postgres".to_string(),
+                id: "src1".to_string(),
+                auto_start: false,
+                identity_provider: None,
+                bootstrap_provider: Some(BootstrapProviderRef::Inline(BootstrapProviderConfig {
+                    kind: "postgres".to_string(),
+                    id: None,
+                    config: serde_json::json!({ "host": "db.local", "tables": ["Message"] }),
+                })),
+                config: serde_json::json!({ "host": "db.local" }),
+            }],
+            ..DrasiServerConfig::default()
+        };
+
+        let core = build_core(
+            "inst1",
+            vec![TestSource::new("src1", "postgres")],
+            vec![],
+            vec![],
+        )
+        .await;
+        let p = make_persistence_with_config(core, "inst1", cfg_path.clone(), true, &original);
+        p.save().await.unwrap();
+
+        let val = read_yaml(&cfg_path);
+        let sources = val["sources"].as_sequence().unwrap();
+        let bp = &sources[0]["bootstrapProvider"];
+        assert!(
+            bp.is_mapping(),
+            "inline bootstrapProvider must be preserved as a mapping, got: {bp:?}"
+        );
+        assert_eq!(bp["kind"].as_str().unwrap(), "postgres");
+        assert_eq!(bp["host"].as_str().unwrap(), "db.local");
+        assert_eq!(bp["tables"][0].as_str().unwrap(), "Message");
+    }
+
+    #[tokio::test]
+    async fn test_save_preserves_toplevel_bootstrap_provider_reference() {
+        // #112: a source referencing a top-level `bootstrapProvider` persists as
+        // a string reference (NOT re-inlined), and the top-level
+        // `bootstrapProviders` block is retained across a save.
+        let tmp = TempDir::new().unwrap();
+        let cfg_path = tmp.path().join("server.yaml");
+
+        let original = DrasiServerConfig {
+            id: ConfigValue::Static("inst1".to_string()),
+            persist_config: true,
+            bootstrap_providers: vec![BootstrapProviderConfig {
+                kind: "postgres".to_string(),
+                id: Some("pg-bootstrap".to_string()),
+                config: serde_json::json!({ "host": "db.local", "tables": ["Message"] }),
+            }],
+            sources: vec![SourceConfig {
+                kind: "postgres".to_string(),
+                id: "src1".to_string(),
+                auto_start: false,
+                identity_provider: None,
+                bootstrap_provider: Some(BootstrapProviderRef::Reference(
+                    "pg-bootstrap".to_string(),
+                )),
+                config: serde_json::json!({ "host": "db.local" }),
+            }],
+            ..DrasiServerConfig::default()
+        };
+
+        let core = build_core(
+            "inst1",
+            vec![TestSource::new("src1", "postgres")],
+            vec![],
+            vec![],
+        )
+        .await;
+        let p = make_persistence_with_config(core, "inst1", cfg_path.clone(), true, &original);
+        p.save().await.unwrap();
+
+        let val = read_yaml(&cfg_path);
+
+        // The source keeps a string reference, not an inlined mapping.
+        let bp = &val["sources"].as_sequence().unwrap()[0]["bootstrapProvider"];
+        assert!(
+            bp.is_string(),
+            "reference must persist as a string, got: {bp:?}"
+        );
+        assert_eq!(bp.as_str().unwrap(), "pg-bootstrap");
+
+        // The top-level bootstrapProviders block is retained with the entry.
+        let providers = val["bootstrapProviders"].as_sequence().unwrap();
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0]["id"].as_str().unwrap(), "pg-bootstrap");
+        assert_eq!(providers[0]["kind"].as_str().unwrap(), "postgres");
     }
 
     #[tokio::test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -29,9 +29,10 @@ use crate::api;
 use crate::api::mappings::{map_server_settings, DtoMapper};
 use crate::config::{DrasiLibInstanceConfig, SecretStoreConfig};
 use crate::factories::{
-    build_config_resolver_context, build_identity_provider_map, config_resolver_callback,
-    create_reaction_locked, create_secret_store_from_registry, create_source_locked,
-    create_state_store_provider,
+    build_bootstrap_provider_config_map, build_config_resolver_context,
+    build_identity_provider_map, config_resolver_callback, create_reaction_locked,
+    create_secret_store_from_registry, create_source_locked, create_state_store_provider,
+    resolve_source_bootstrap_provider,
 };
 use crate::instance_paths::instance_storage_key;
 use crate::instance_registry::InstanceRegistry;
@@ -495,13 +496,19 @@ impl DrasiServer {
             // reactions can reference entries here via `identityProvider: <id>`.
             let identity_providers =
                 build_identity_provider_map(&plugin_registry, &instance.identity_providers).await?;
+            // Build the bootstrap-provider config map for this instance. Sources
+            // can reference entries here via `bootstrapProvider: <id>`; each
+            // referencing source instantiates its own provider from the config.
+            let bootstrap_providers =
+                build_bootstrap_provider_config_map(&instance.bootstrap_providers)?;
             // Create and add sources from config
             info!(
                 "Loading {} source(s) from configuration for instance '{}'",
                 instance.sources.len(),
                 instance.id
             );
-            for source_config in instance.sources.clone() {
+            for mut source_config in instance.sources.clone() {
+                resolve_source_bootstrap_provider(&mut source_config, &bootstrap_providers)?;
                 let identity_ref = source_config.identity_provider().map(str::to_string);
                 let (source, plugin_meta) =
                     create_source_locked(&plugin_registry, source_config).await?;
@@ -739,6 +746,7 @@ impl DrasiServer {
                                 queries: config.queries.clone(),
                                 reactions: config.reactions.clone(),
                                 identity_providers: config.identity_providers.clone(),
+                                bootstrap_providers: config.bootstrap_providers.clone(),
                             }]
                         } else {
                             config.instances.clone()

--- a/src/server.rs
+++ b/src/server.rs
@@ -514,8 +514,9 @@ impl DrasiServer {
                 instance.sources.len(),
                 instance.id
             );
-            for mut source_config in instance.sources.clone() {
-                resolve_source_bootstrap_provider(&mut source_config, &bootstrap_providers)?;
+            for source_config in instance.sources.clone() {
+                let source_config =
+                    resolve_source_bootstrap_provider(source_config, &bootstrap_providers)?;
                 let identity_ref = source_config.identity_provider().map(str::to_string);
                 let (source, plugin_meta) =
                     create_source_locked(&plugin_registry, source_config).await?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -16,6 +16,7 @@ use anyhow::Result;
 use axum::{routing::get, Router};
 use indexmap::IndexMap;
 use log::{debug, error, info, warn};
+use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -27,6 +28,7 @@ use utoipa_swagger_ui::SwaggerUi;
 
 use crate::api;
 use crate::api::mappings::{map_server_settings, DtoMapper};
+use crate::api::models::BootstrapProviderConfig;
 use crate::config::{DrasiLibInstanceConfig, SecretStoreConfig};
 use crate::factories::{
     build_bootstrap_provider_config_map, build_config_resolver_context,
@@ -64,6 +66,11 @@ struct PreparedInstance {
     id_hint: Option<String>,
     persist_index: bool,
     core: DrasiLib,
+    /// Top-level bootstrap provider configs declared for this instance,
+    /// keyed by provider id. Registered into the `InstanceRegistry` so
+    /// runtime-created sources can resolve `bootstrapProvider: <id>`
+    /// references. Empty for programmatically built instances.
+    bootstrap_providers: HashMap<String, BootstrapProviderConfig>,
 }
 
 impl DrasiServer {
@@ -558,6 +565,7 @@ impl DrasiServer {
                 id_hint: Some(instance.id),
                 persist_index: instance.persist_index,
                 core,
+                bootstrap_providers,
             });
         }
 
@@ -595,6 +603,7 @@ impl DrasiServer {
                 id_hint: None,
                 persist_index: false,
                 core,
+                bootstrap_providers: HashMap::new(),
             }],
             enable_api,
             enable_ui,
@@ -624,6 +633,7 @@ impl DrasiServer {
                 id_hint,
                 persist_index,
                 core,
+                bootstrap_providers: HashMap::new(),
             })
             .collect();
 
@@ -671,11 +681,14 @@ impl DrasiServer {
 
         let mut instance_map: IndexMap<String, Arc<DrasiLib>> = IndexMap::new();
         let mut persist_settings: IndexMap<String, bool> = IndexMap::new();
+        let mut bootstrap_providers_by_id: Vec<(String, HashMap<String, BootstrapProviderConfig>)> =
+            Vec::new();
 
         // Take ownership of instances to avoid partial move of self
         let instances = std::mem::take(&mut self.instances);
         for instance in instances {
             let core = instance.core;
+            let bootstrap_providers = instance.bootstrap_providers;
             let id = match instance.id_hint {
                 Some(id) => id,
                 None => core
@@ -688,6 +701,7 @@ impl DrasiServer {
             let core = Arc::new(core);
             core.start().await?;
             persist_settings.insert(id.clone(), instance.persist_index);
+            bootstrap_providers_by_id.push((id.clone(), bootstrap_providers));
             instance_map.insert(id, core);
         }
 
@@ -702,6 +716,13 @@ impl DrasiServer {
 
         // Create the instance registry from the map
         let registry = InstanceRegistry::from_map((*instances).clone());
+
+        // Record each instance's top-level bootstrap provider configs so the
+        // source create/upsert handlers can resolve `bootstrapProvider: <id>`
+        // references for sources created at runtime.
+        for (id, providers) in bootstrap_providers_by_id {
+            registry.set_bootstrap_providers(id, providers).await;
+        }
 
         // Initialize persistence and extract solutions_dir if config file is provided
         let (config_persistence, solutions_dir) = if let Some(config_file) = &self.config_file_path

--- a/tests/error_resilience_test.rs
+++ b/tests/error_resilience_test.rs
@@ -71,6 +71,7 @@ async fn test_unknown_bootstrap_kind_returns_helpful_error() {
     let registry = core_registry();
     let bootstrap_config = BootstrapProviderConfig {
         kind: "imaginary-bootstrap".to_string(),
+        id: None,
         config: serde_json::json!({}),
     };
     let source_config_json = serde_json::json!({});

--- a/tests/error_resilience_test.rs
+++ b/tests/error_resilience_test.rs
@@ -71,7 +71,6 @@ async fn test_unknown_bootstrap_kind_returns_helpful_error() {
     let registry = core_registry();
     let bootstrap_config = BootstrapProviderConfig {
         kind: "imaginary-bootstrap".to_string(),
-        id: None,
         config: serde_json::json!({}),
     };
     let source_config_json = serde_json::json!({});

--- a/tests/init_output_test.rs
+++ b/tests/init_output_test.rs
@@ -384,7 +384,6 @@ fn test_postgres_source_generates_valid_yaml() {
             identity_provider: None,
             bootstrap_provider: Some(BootstrapProviderRef::Inline(BootstrapProviderConfig {
                 kind: "postgres".to_string(),
-                id: None,
                 config: serde_json::json!({
                     "host": "localhost",
                     "port": 5432,
@@ -479,7 +478,6 @@ fn test_postgres_bootstrap_provider_generates_valid_yaml() {
             identity_provider: None,
             bootstrap_provider: Some(BootstrapProviderRef::Inline(BootstrapProviderConfig {
                 kind: "postgres".to_string(),
-                id: None,
                 config: serde_json::json!({
                     "host": "localhost",
                     "port": 5432,
@@ -556,7 +554,6 @@ fn test_scriptfile_bootstrap_provider_generates_valid_yaml() {
             identity_provider: None,
             bootstrap_provider: Some(BootstrapProviderRef::Inline(BootstrapProviderConfig {
                 kind: "scriptfile".to_string(),
-                id: None,
                 config: serde_json::json!({
                     "filePaths": ["/data/init.jsonl"]
                 }),
@@ -619,7 +616,6 @@ fn test_noop_bootstrap_provider_generates_valid_yaml() {
             identity_provider: None,
             bootstrap_provider: Some(BootstrapProviderRef::Inline(BootstrapProviderConfig {
                 kind: "noop".to_string(),
-                id: None,
                 config: serde_json::json!({}),
             })),
             config: json!({"dataType": {"type": "generic"}, "intervalMs": 5000}),
@@ -968,7 +964,6 @@ fn test_full_config_roundtrip() {
             identity_provider: None,
             bootstrap_provider: Some(BootstrapProviderRef::Inline(BootstrapProviderConfig {
                 kind: "scriptfile".to_string(),
-                id: None,
                 config: serde_json::json!({
                     "filePaths": ["/data/init.jsonl"]
                 }),

--- a/tests/init_output_test.rs
+++ b/tests/init_output_test.rs
@@ -155,6 +155,7 @@ fn test_empty_config_generates_valid_yaml() {
         cors_allowed_origins: Vec::new(),
         solutions_dir: None,
         identity_providers: vec![],
+        bootstrap_providers: vec![],
     };
 
     let yaml = serde_yaml::to_string(&config).expect("Should serialize to YAML");
@@ -196,6 +197,7 @@ fn test_config_with_state_store_generates_valid_yaml() {
         cors_allowed_origins: Vec::new(),
         solutions_dir: None,
         identity_providers: vec![],
+        bootstrap_providers: vec![],
     };
 
     let yaml = serde_yaml::to_string(&config).expect("Should serialize to YAML");
@@ -249,6 +251,7 @@ fn test_mock_source_generates_valid_yaml() {
         cors_allowed_origins: Vec::new(),
         solutions_dir: None,
         identity_providers: vec![],
+        bootstrap_providers: vec![],
     };
 
     let yaml = serde_yaml::to_string(&config).expect("Should serialize to YAML");
@@ -298,6 +301,7 @@ fn test_http_source_generates_valid_yaml() {
         cors_allowed_origins: Vec::new(),
         solutions_dir: None,
         identity_providers: vec![],
+        bootstrap_providers: vec![],
     };
 
     let yaml = serde_yaml::to_string(&config).expect("Should serialize to YAML");
@@ -346,6 +350,7 @@ fn test_grpc_source_generates_valid_yaml() {
         cors_allowed_origins: Vec::new(),
         solutions_dir: None,
         identity_providers: vec![],
+        bootstrap_providers: vec![],
     };
 
     let yaml = serde_yaml::to_string(&config).expect("Should serialize to YAML");
@@ -377,8 +382,9 @@ fn test_postgres_source_generates_valid_yaml() {
             id: "postgres-source".to_string(),
             auto_start: true,
             identity_provider: None,
-            bootstrap_provider: Some(BootstrapProviderConfig {
+            bootstrap_provider: Some(BootstrapProviderRef::Inline(BootstrapProviderConfig {
                 kind: "postgres".to_string(),
+                id: None,
                 config: serde_json::json!({
                     "host": "localhost",
                     "port": 5432,
@@ -391,7 +397,7 @@ fn test_postgres_source_generates_valid_yaml() {
                     "sslMode": "prefer",
                     "tableKeys": [{"table": "users", "keyColumns": ["id"]}]
                 }),
-            }),
+            })),
             config: json!({
                 "host": "localhost",
                 "port": 5432,
@@ -418,6 +424,7 @@ fn test_postgres_source_generates_valid_yaml() {
         cors_allowed_origins: Vec::new(),
         solutions_dir: None,
         identity_providers: vec![],
+        bootstrap_providers: vec![],
     };
 
     let yaml = serde_yaml::to_string(&config).expect("Should serialize to YAML");
@@ -470,8 +477,9 @@ fn test_postgres_bootstrap_provider_generates_valid_yaml() {
             id: "mock-source".to_string(),
             auto_start: true,
             identity_provider: None,
-            bootstrap_provider: Some(BootstrapProviderConfig {
+            bootstrap_provider: Some(BootstrapProviderRef::Inline(BootstrapProviderConfig {
                 kind: "postgres".to_string(),
+                id: None,
                 config: serde_json::json!({
                     "host": "localhost",
                     "port": 5432,
@@ -484,7 +492,7 @@ fn test_postgres_bootstrap_provider_generates_valid_yaml() {
                     "sslMode": "prefer",
                     "tableKeys": [{"table": "users", "keyColumns": ["id"]}]
                 }),
-            }),
+            })),
             config: json!({"dataType": {"type": "generic"}, "intervalMs": 5000}),
         }],
         queries: vec![],
@@ -500,6 +508,7 @@ fn test_postgres_bootstrap_provider_generates_valid_yaml() {
         cors_allowed_origins: Vec::new(),
         solutions_dir: None,
         identity_providers: vec![],
+        bootstrap_providers: vec![],
     };
 
     let yaml = serde_yaml::to_string(&config).expect("Should serialize to YAML");
@@ -545,12 +554,13 @@ fn test_scriptfile_bootstrap_provider_generates_valid_yaml() {
             id: "mock-source".to_string(),
             auto_start: true,
             identity_provider: None,
-            bootstrap_provider: Some(BootstrapProviderConfig {
+            bootstrap_provider: Some(BootstrapProviderRef::Inline(BootstrapProviderConfig {
                 kind: "scriptfile".to_string(),
+                id: None,
                 config: serde_json::json!({
                     "filePaths": ["/data/init.jsonl"]
                 }),
-            }),
+            })),
             config: json!({"dataType": {"type": "generic"}, "intervalMs": 5000}),
         }],
         queries: vec![],
@@ -566,6 +576,7 @@ fn test_scriptfile_bootstrap_provider_generates_valid_yaml() {
         cors_allowed_origins: Vec::new(),
         solutions_dir: None,
         identity_providers: vec![],
+        bootstrap_providers: vec![],
     };
 
     let yaml = serde_yaml::to_string(&config).expect("Should serialize to YAML");
@@ -606,10 +617,11 @@ fn test_noop_bootstrap_provider_generates_valid_yaml() {
             id: "mock-source".to_string(),
             auto_start: true,
             identity_provider: None,
-            bootstrap_provider: Some(BootstrapProviderConfig {
+            bootstrap_provider: Some(BootstrapProviderRef::Inline(BootstrapProviderConfig {
                 kind: "noop".to_string(),
+                id: None,
                 config: serde_json::json!({}),
-            }),
+            })),
             config: json!({"dataType": {"type": "generic"}, "intervalMs": 5000}),
         }],
         queries: vec![],
@@ -625,6 +637,7 @@ fn test_noop_bootstrap_provider_generates_valid_yaml() {
         cors_allowed_origins: Vec::new(),
         solutions_dir: None,
         identity_providers: vec![],
+        bootstrap_providers: vec![],
     };
 
     let yaml = serde_yaml::to_string(&config).expect("Should serialize to YAML");
@@ -679,6 +692,7 @@ fn test_log_reaction_generates_valid_yaml() {
         cors_allowed_origins: Vec::new(),
         solutions_dir: None,
         identity_providers: vec![],
+        bootstrap_providers: vec![],
     };
 
     let yaml = serde_yaml::to_string(&config).expect("Should serialize to YAML");
@@ -727,6 +741,7 @@ fn test_http_reaction_generates_valid_yaml() {
         cors_allowed_origins: Vec::new(),
         solutions_dir: None,
         identity_providers: vec![],
+        bootstrap_providers: vec![],
     };
 
     let yaml = serde_yaml::to_string(&config).expect("Should serialize to YAML");
@@ -776,6 +791,7 @@ fn test_sse_reaction_generates_valid_yaml() {
         cors_allowed_origins: Vec::new(),
         solutions_dir: None,
         identity_providers: vec![],
+        bootstrap_providers: vec![],
     };
 
     let yaml = serde_yaml::to_string(&config).expect("Should serialize to YAML");
@@ -828,6 +844,7 @@ fn test_grpc_reaction_generates_valid_yaml() {
         cors_allowed_origins: Vec::new(),
         solutions_dir: None,
         identity_providers: vec![],
+        bootstrap_providers: vec![],
     };
 
     let yaml = serde_yaml::to_string(&config).expect("Should serialize to YAML");
@@ -899,6 +916,7 @@ fn test_query_generates_valid_yaml() {
         cors_allowed_origins: Vec::new(),
         solutions_dir: None,
         identity_providers: vec![],
+        bootstrap_providers: vec![],
     };
 
     let yaml = serde_yaml::to_string(&config).expect("Should serialize to YAML");
@@ -948,12 +966,13 @@ fn test_full_config_roundtrip() {
             id: "mock-source".to_string(),
             auto_start: true,
             identity_provider: None,
-            bootstrap_provider: Some(BootstrapProviderConfig {
+            bootstrap_provider: Some(BootstrapProviderRef::Inline(BootstrapProviderConfig {
                 kind: "scriptfile".to_string(),
+                id: None,
                 config: serde_json::json!({
                     "filePaths": ["/data/init.jsonl"]
                 }),
-            }),
+            })),
             config: json!({"dataType": {"type": "sensorReading", "sensorCount": 5}, "intervalMs": 5000}),
         }],
         queries: vec![QueryConfigDto {
@@ -997,6 +1016,7 @@ fn test_full_config_roundtrip() {
         cors_allowed_origins: Vec::new(),
         solutions_dir: None,
         identity_providers: vec![],
+        bootstrap_providers: vec![],
     };
 
     let yaml = serde_yaml::to_string(&config).expect("Should serialize to YAML");


### PR DESCRIPTION
# Description


## Summary

Bootstrap providers (BSPs) can now be declared as **top-level configuration
components** and referenced by sources by id, mirroring how identity providers
work — while the existing **inline** form continues to work unchanged. This also
fixes a data-loss bug where bootstrap provider config was dropped on persist.

## What changed

- **Top-level `bootstrapProviders`**: a new server/instance-level list of
  `{ kind, id, ...config }` entries, referenced by sources via
  `bootstrapProvider: <id>`.
- **Hybrid / backward compatible**: the source `bootstrapProvider` field now
  accepts *either* a string (reference to a top-level entry) *or* a mapping
  (inline definition). Existing configs keep working.
- **Persistence fixed (#105)**: inline definitions and top-level references now
  round-trip through `save()`. Inline blocks are preserved; references persist
  as references (not re-inlined), and the top-level block is retained.
- **Runtime wiring**: sources created at runtime via the REST API that
  *reference* a top-level provider are now wired and bootstrap **live** (no
  restart needed).
- **Generic same-kind inheritance**: removed the hardcoded per-kind field
  allowlist. An inline bootstrapper of the **same kind** as its source now
  inherits *all* of the source's config it doesn't override — for any plugin
  kind (e.g. MySQL), with no server-side changes.
- **Validation**: dangling references, missing ids, and duplicate ids are
  rejected at config-validation/startup time with clear errors.

## Design decisions

- **Non-singleton sharing**: when multiple sources reference the same top-level
  provider, each source instantiates its **own** provider instance from the
  shared config. drasi-lib takes an owned `Box<dyn BootstrapProvider>`, so true
  singletons would require an upstream `Arc` change; per-instance is also the
  cleaner design (isolation, simpler lifecycle) and the config is still defined
  once.
- **Inline = minimal, top-level = shared**: inline inherits from its source (least
  duplication for one source); top-level is fully specified and reusable across
  many sources (no inheritance, since there's no single owning source).
- **Mix-and-match supported**: a source may use a *different-kind* bootstrapper
  (e.g. an `http` source with a `scriptfile` bootstrapper). Different kinds are
  configured explicitly (no inheritance), which is correct.
- **Config-only, like identity providers**: no new REST CRUD endpoints for
  providers themselves; they're managed via config/startup.

## Config examples

Top-level, shared by reference:

```yaml
bootstrapProviders:
  - kind: postgres
    id: pg-bootstrap
    host: localhost
    port: 5432
    database: getting_started
    user: drasi_user
    password: ${PG_PASSWORD}
    tables: [Message]

sources:
  - kind: postgres
    id: source-a
    bootstrapProvider: pg-bootstrap   # reference by id
    # ...source connection config...
```

Inline (still supported), minimal same-kind inheritance:

```yaml
sources:
  - kind: mysql
    id: my-mysql
    host: db.internal
    port: 3306
    database: shop
    user: app
    password: s3cret
    tables: [Orders]
    bootstrapProvider:
      kind: mysql        # inherits host/port/database/user/password/tables
```

## Backward compatibility

Fully backward compatible. Existing inline `bootstrapProvider` mappings parse and
behave as before, and now also persist correctly.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now.

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #112  #105 
