### PR TITLE
fix(vscode): store connection settings in user scope

### DIFF
--- a/dev-tools/vscode/drasi-server/README.md
+++ b/dev-tools/vscode/drasi-server/README.md
@@ -28,9 +28,9 @@ Connection and binary settings are stored in **user** settings (not workspace), 
 |---------|-------|-------------|
 | `drasiServer.connections` | User | Saved server connections |
 | `drasiServer.currentConnectionId` | User | Active connection ID |
-| `drasiServer.binaryPath` | User (machine) | Path to the `drasi-server` binary (used by the Launch Server command) |
-| `drasiServer.url` | User (legacy) | Seed URL for the first connection only (default: `http://localhost:8080`) |
-| `drasiServer.instanceId` | User (legacy) | Seed instance ID for the first connection only |
+| `drasiServer.binaryPath` | User | Path to the `drasi-server` binary (used by the Launch Server command) |
+| `drasiServer.url` | User | Seed URL for the first connection only — **legacy**, prefer `drasiServer.connections` (default: `http://localhost:8080`) |
+| `drasiServer.instanceId` | User | Seed instance ID for the first connection only — **legacy**, prefer `drasiServer.connections` |
 
 ## Getting Started
 

--- a/dev-tools/vscode/drasi-server/README.md
+++ b/dev-tools/vscode/drasi-server/README.md
@@ -22,13 +22,15 @@ The **Drasi Server** extension provides tools for managing and debugging Drasi S
 
 ## Configuration
 
-| Setting | Description |
-|---------|-------------|
-| `drasiServer.url` | Base URL for the Drasi Server API (default: `http://localhost:8080`) |
-| `drasiServer.instanceId` | Optional instance ID to use; if empty, the first instance is selected |
-| `drasiServer.connections` | Saved server connections |
-| `drasiServer.currentConnectionId` | Active connection ID |
-| `drasiServer.binaryPath` | Path to the `drasi-server` binary (used by the Launch Server command) |
+Connection and binary settings are stored in **user** settings (not workspace), so personal server URLs are not written to `.vscode/settings.json`.
+
+| Setting | Scope | Description |
+|---------|-------|-------------|
+| `drasiServer.connections` | User | Saved server connections |
+| `drasiServer.currentConnectionId` | User | Active connection ID |
+| `drasiServer.binaryPath` | User (machine) | Path to the `drasi-server` binary (used by the Launch Server command) |
+| `drasiServer.url` | User (legacy) | Seed URL for the first connection only (default: `http://localhost:8080`) |
+| `drasiServer.instanceId` | User (legacy) | Seed instance ID for the first connection only |
 
 ## Getting Started
 

--- a/dev-tools/vscode/drasi-server/package.json
+++ b/dev-tools/vscode/drasi-server/package.json
@@ -373,20 +373,20 @@
         "drasiServer.url": {
           "type": "string",
           "default": "http://localhost:8080",
-          "scope": "application",
+          "scope": "machine",
           "description": "Legacy base URL used only to seed the first connection. Prefer drasiServer.connections."
         },
         "drasiServer.instanceId": {
           "type": "string",
           "default": "",
-          "scope": "application",
+          "scope": "machine",
           "description": "Legacy instance ID used only to seed the first connection. Prefer drasiServer.connections."
         },
         "drasiServer.connections": {
           "type": "array",
           "default": [],
-          "scope": "application",
-          "description": "Saved Drasi Server connections (user settings).",
+          "scope": "machine",
+          "description": "Saved Drasi Server connections.",
           "items": {
             "type": "object",
             "properties": {
@@ -400,14 +400,14 @@
         "drasiServer.currentConnectionId": {
           "type": "string",
           "default": "",
-          "scope": "application",
-          "description": "Active Drasi Server connection ID (user settings)."
+          "scope": "machine",
+          "description": "Active Drasi Server connection ID."
         },
         "drasiServer.binaryPath": {
           "type": "string",
           "default": "",
           "scope": "machine",
-          "description": "Path to the drasi-server binary. Used by the Launch Server command (user/machine settings)."
+          "description": "Path to the drasi-server binary. Used by the Launch Server command."
         }
       }
     }

--- a/dev-tools/vscode/drasi-server/package.json
+++ b/dev-tools/vscode/drasi-server/package.json
@@ -3,7 +3,7 @@
   "displayName": "Drasi Server",
   "publisher": "DrasiProject",
   "description": "The Drasi Server Visual Studio Code Extension",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "icon": "resources/drasi.png",
   "repository": {
     "type": "git",
@@ -373,17 +373,20 @@
         "drasiServer.url": {
           "type": "string",
           "default": "http://localhost:8080",
-          "description": "Base URL for the Drasi Server API."
+          "scope": "application",
+          "description": "Legacy base URL used only to seed the first connection. Prefer drasiServer.connections."
         },
         "drasiServer.instanceId": {
           "type": "string",
           "default": "",
-          "description": "Optional instance ID to use. If empty, the first instance is selected."
+          "scope": "application",
+          "description": "Legacy instance ID used only to seed the first connection. Prefer drasiServer.connections."
         },
         "drasiServer.connections": {
           "type": "array",
           "default": [],
-          "description": "Saved Drasi Server connections.",
+          "scope": "application",
+          "description": "Saved Drasi Server connections (user settings).",
           "items": {
             "type": "object",
             "properties": {
@@ -397,12 +400,14 @@
         "drasiServer.currentConnectionId": {
           "type": "string",
           "default": "",
-          "description": "Active Drasi Server connection ID."
+          "scope": "application",
+          "description": "Active Drasi Server connection ID (user settings)."
         },
         "drasiServer.binaryPath": {
           "type": "string",
           "default": "",
-          "description": "Path to the drasi-server binary. Used by the Launch Server command."
+          "scope": "machine",
+          "description": "Path to the drasi-server binary. Used by the Launch Server command (user/machine settings)."
         }
       }
     }

--- a/dev-tools/vscode/drasi-server/src/extension.ts
+++ b/dev-tools/vscode/drasi-server/src/extension.ts
@@ -13,6 +13,8 @@ let drasiClient: DrasiClient | undefined;
 
 export async function activate(context: vscode.ExtensionContext) {
   const registry = new ConnectionRegistry();
+  // Promote legacy workspace-scoped connection settings to user settings (#78).
+  await registry.migrateWorkspaceSettingsToGlobal();
   await registry.ensureDefaultConnection();
   drasiClient = new DrasiClient(registry);
 

--- a/dev-tools/vscode/drasi-server/src/extension.ts
+++ b/dev-tools/vscode/drasi-server/src/extension.ts
@@ -13,8 +13,6 @@ let drasiClient: DrasiClient | undefined;
 
 export async function activate(context: vscode.ExtensionContext) {
   const registry = new ConnectionRegistry();
-  // Promote legacy workspace-scoped connection settings to user settings (#78).
-  await registry.migrateWorkspaceSettingsToGlobal();
   await registry.ensureDefaultConnection();
   drasiClient = new DrasiClient(registry);
 

--- a/dev-tools/vscode/drasi-server/src/sdk/config.ts
+++ b/dev-tools/vscode/drasi-server/src/sdk/config.ts
@@ -11,29 +11,6 @@ export interface ServerConnectionConfig {
 export class ConnectionRegistry {
   private readonly configurationSection = 'drasiServer';
 
-  /**
-   * Move personal connection settings from workspace scope to user (global)
-   * scope and clear any leftover workspace values so they stop shadowing.
-   *
-   * Safe to call repeatedly — no-ops when workspace has nothing set.
-   */
-  async migrateWorkspaceSettingsToGlobal(): Promise<boolean> {
-    const config = vscode.workspace.getConfiguration(this.configurationSection);
-    let migrated = false;
-
-    migrated =
-      (await this.migrateSettingToGlobal<ServerConnectionConfig[]>(config, 'connections', (value) =>
-        Array.isArray(value) && value.length > 0
-      )) || migrated;
-
-    migrated =
-      (await this.migrateSettingToGlobal<string>(config, 'currentConnectionId', (value) =>
-        typeof value === 'string' && value.length > 0
-      )) || migrated;
-
-    return migrated;
-  }
-
   async ensureDefaultConnection(): Promise<ServerConnectionConfig> {
     const connections = this.getConnections();
     if (connections.length > 0) {
@@ -134,49 +111,5 @@ export class ConnectionRegistry {
   private async setConnections(connections: ServerConnectionConfig[]) {
     const config = vscode.workspace.getConfiguration(this.configurationSection);
     await config.update('connections', connections, vscode.ConfigurationTarget.Global);
-  }
-
-  private async migrateSettingToGlobal<T>(
-    config: vscode.WorkspaceConfiguration,
-    key: string,
-    isPresent: (value: T | undefined) => boolean
-  ): Promise<boolean> {
-    const inspected = config.inspect<T>(key);
-    if (!inspected) {
-      return false;
-    }
-
-    const workspaceValue = inspected.workspaceValue;
-    const workspaceFolderValue = inspected.workspaceFolderValue;
-    const hasWorkspace = isPresent(workspaceValue);
-    const hasWorkspaceFolder = isPresent(workspaceFolderValue);
-
-    if (!hasWorkspace && !hasWorkspaceFolder) {
-      return false;
-    }
-
-    // Prefer existing user settings; only promote workspace values when global is empty.
-    if (!isPresent(inspected.globalValue)) {
-      const valueToPromote = hasWorkspace ? workspaceValue : workspaceFolderValue;
-      await config.update(key, valueToPromote, vscode.ConfigurationTarget.Global);
-    }
-
-    // Clearing may fail for application-scoped settings; ignore so activation still succeeds.
-    if (hasWorkspace) {
-      try {
-        await config.update(key, undefined, vscode.ConfigurationTarget.Workspace);
-      } catch {
-        // ignore
-      }
-    }
-    if (hasWorkspaceFolder) {
-      try {
-        await config.update(key, undefined, vscode.ConfigurationTarget.WorkspaceFolder);
-      } catch {
-        // ignore
-      }
-    }
-
-    return true;
   }
 }

--- a/dev-tools/vscode/drasi-server/src/sdk/config.ts
+++ b/dev-tools/vscode/drasi-server/src/sdk/config.ts
@@ -11,6 +11,29 @@ export interface ServerConnectionConfig {
 export class ConnectionRegistry {
   private readonly configurationSection = 'drasiServer';
 
+  /**
+   * Move personal connection settings from workspace scope to user (global)
+   * scope and clear any leftover workspace values so they stop shadowing.
+   *
+   * Safe to call repeatedly — no-ops when workspace has nothing set.
+   */
+  async migrateWorkspaceSettingsToGlobal(): Promise<boolean> {
+    const config = vscode.workspace.getConfiguration(this.configurationSection);
+    let migrated = false;
+
+    migrated =
+      (await this.migrateSettingToGlobal<ServerConnectionConfig[]>(config, 'connections', (value) =>
+        Array.isArray(value) && value.length > 0
+      )) || migrated;
+
+    migrated =
+      (await this.migrateSettingToGlobal<string>(config, 'currentConnectionId', (value) =>
+        typeof value === 'string' && value.length > 0
+      )) || migrated;
+
+    return migrated;
+  }
+
   async ensureDefaultConnection(): Promise<ServerConnectionConfig> {
     const connections = this.getConnections();
     if (connections.length > 0) {
@@ -90,8 +113,7 @@ export class ConnectionRegistry {
 
   async setCurrentConnectionId(connectionId: string) {
     const config = vscode.workspace.getConfiguration(this.configurationSection);
-    const target = this.getConfigurationTarget();
-    await config.update('currentConnectionId', connectionId, target);
+    await config.update('currentConnectionId', connectionId, vscode.ConfigurationTarget.Global);
   }
 
   async setCurrentInstanceId(instanceId: string) {
@@ -111,13 +133,50 @@ export class ConnectionRegistry {
 
   private async setConnections(connections: ServerConnectionConfig[]) {
     const config = vscode.workspace.getConfiguration(this.configurationSection);
-    const target = this.getConfigurationTarget();
-    await config.update('connections', connections, target);
+    await config.update('connections', connections, vscode.ConfigurationTarget.Global);
   }
 
-  private getConfigurationTarget(): vscode.ConfigurationTarget {
-    return vscode.workspace.workspaceFolders
-      ? vscode.ConfigurationTarget.Workspace
-      : vscode.ConfigurationTarget.Global;
+  private async migrateSettingToGlobal<T>(
+    config: vscode.WorkspaceConfiguration,
+    key: string,
+    isPresent: (value: T | undefined) => boolean
+  ): Promise<boolean> {
+    const inspected = config.inspect<T>(key);
+    if (!inspected) {
+      return false;
+    }
+
+    const workspaceValue = inspected.workspaceValue;
+    const workspaceFolderValue = inspected.workspaceFolderValue;
+    const hasWorkspace = isPresent(workspaceValue);
+    const hasWorkspaceFolder = isPresent(workspaceFolderValue);
+
+    if (!hasWorkspace && !hasWorkspaceFolder) {
+      return false;
+    }
+
+    // Prefer existing user settings; only promote workspace values when global is empty.
+    if (!isPresent(inspected.globalValue)) {
+      const valueToPromote = hasWorkspace ? workspaceValue : workspaceFolderValue;
+      await config.update(key, valueToPromote, vscode.ConfigurationTarget.Global);
+    }
+
+    // Clearing may fail for application-scoped settings; ignore so activation still succeeds.
+    if (hasWorkspace) {
+      try {
+        await config.update(key, undefined, vscode.ConfigurationTarget.Workspace);
+      } catch {
+        // ignore
+      }
+    }
+    if (hasWorkspaceFolder) {
+      try {
+        await config.update(key, undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+      } catch {
+        // ignore
+      }
+    }
+
+    return true;
   }
 }

--- a/dev-tools/vscode/drasi-server/src/server-launcher.ts
+++ b/dev-tools/vscode/drasi-server/src/server-launcher.ts
@@ -52,10 +52,10 @@ export class ServerLauncher {
     }
 
     const selected = result[0].fsPath;
-    const target = vscode.workspace.workspaceFolders
-      ? vscode.ConfigurationTarget.Workspace
-      : vscode.ConfigurationTarget.Global;
-    await vscode.workspace.getConfiguration().update(BINARY_PATH_SETTING, selected, target);
+    // Machine-local binary path belongs in user settings, not the workspace (#78).
+    await vscode.workspace
+      .getConfiguration()
+      .update(BINARY_PATH_SETTING, selected, vscode.ConfigurationTarget.Global);
     vscode.window.showInformationMessage(`Drasi Server binary set to: ${selected}`);
   }
 
@@ -77,10 +77,9 @@ export class ServerLauncher {
     }
 
     const selected = result[0].fsPath;
-    const target = vscode.workspace.workspaceFolders
-      ? vscode.ConfigurationTarget.Workspace
-      : vscode.ConfigurationTarget.Global;
-    await vscode.workspace.getConfiguration().update(BINARY_PATH_SETTING, selected, target);
+    await vscode.workspace
+      .getConfiguration()
+      .update(BINARY_PATH_SETTING, selected, vscode.ConfigurationTarget.Global);
     return selected;
   }
 }

--- a/dev-tools/vscode/drasi-server/src/test/suite/connection-registry.test.ts
+++ b/dev-tools/vscode/drasi-server/src/test/suite/connection-registry.test.ts
@@ -1,0 +1,148 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { ConnectionRegistry, ServerConnectionConfig } from '../../sdk/config';
+
+const SECTION = 'drasiServer';
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function clearConnectionSettings() {
+  const config = vscode.workspace.getConfiguration(SECTION);
+  await config.update('connections', undefined, vscode.ConfigurationTarget.Global);
+  await config.update('currentConnectionId', undefined, vscode.ConfigurationTarget.Global);
+
+  // Best-effort workspace cleanup (may no-op when settings are application-scoped).
+  try {
+    await config.update('connections', undefined, vscode.ConfigurationTarget.Workspace);
+    await config.update('currentConnectionId', undefined, vscode.ConfigurationTarget.Workspace);
+  } catch {
+    // ignore
+  }
+
+  const workspaceRoot = process.env.TEST_WORKSPACE ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  if (workspaceRoot) {
+    const settingsPath = path.join(workspaceRoot, '.vscode', 'settings.json');
+    if (fs.existsSync(settingsPath)) {
+      try {
+        const raw = JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
+        delete raw['drasiServer.connections'];
+        delete raw['drasiServer.currentConnectionId'];
+        fs.writeFileSync(settingsPath, `${JSON.stringify(raw, null, 2)}\n`);
+      } catch {
+        // ignore corrupt/missing settings during cleanup
+      }
+    }
+  }
+}
+
+suite('ConnectionRegistry settings scope', () => {
+  setup(async () => {
+    await clearConnectionSettings();
+  });
+
+  teardown(async () => {
+    await clearConnectionSettings();
+  });
+
+  test('writes connections and currentConnectionId to Global, not Workspace', async () => {
+    assert.ok(
+      vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0,
+      'Test host must open a workspace folder'
+    );
+
+    const registry = new ConnectionRegistry();
+    const connection = await registry.addConnection('Test Server', 'http://example.test:9090');
+
+    const config = vscode.workspace.getConfiguration(SECTION);
+    const connectionsInspect = config.inspect<ServerConnectionConfig[]>('connections');
+    const currentIdInspect = config.inspect<string>('currentConnectionId');
+
+    assert.ok(connectionsInspect?.globalValue, 'connections should be stored in global/user settings');
+    assert.strictEqual(
+      connectionsInspect?.workspaceValue,
+      undefined,
+      'connections must not be workspace-scoped'
+    );
+    assert.strictEqual(connectionsInspect?.globalValue?.[0]?.url, 'http://example.test:9090');
+
+    assert.strictEqual(currentIdInspect?.globalValue, connection.id);
+    assert.strictEqual(
+      currentIdInspect?.workspaceValue,
+      undefined,
+      'currentConnectionId must not be workspace-scoped'
+    );
+  });
+
+  test('ensureDefaultConnection does not write workspace settings', async () => {
+    const registry = new ConnectionRegistry();
+    await registry.ensureDefaultConnection();
+
+    const config = vscode.workspace.getConfiguration(SECTION);
+    const connectionsInspect = config.inspect<ServerConnectionConfig[]>('connections');
+    const currentIdInspect = config.inspect<string>('currentConnectionId');
+
+    assert.ok(connectionsInspect?.globalValue && connectionsInspect.globalValue.length > 0);
+    assert.strictEqual(connectionsInspect?.workspaceValue, undefined);
+    assert.ok(currentIdInspect?.globalValue);
+    assert.strictEqual(currentIdInspect?.workspaceValue, undefined);
+  });
+
+  test('migrateWorkspaceSettingsToGlobal is a no-op when workspace is clean', async () => {
+    const registry = new ConnectionRegistry();
+    const migrated = await registry.migrateWorkspaceSettingsToGlobal();
+    assert.strictEqual(migrated, false);
+  });
+
+  test('migrates workspace connections seeded via settings.json when visible to inspect', async function () {
+    const workspaceRoot = process.env.TEST_WORKSPACE ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    if (!workspaceRoot) {
+      assert.fail('No workspace root');
+    }
+
+    const workspaceConnections: ServerConnectionConfig[] = [
+      {
+        id: 'ws-conn-1',
+        name: 'Workspace Server',
+        url: 'http://workspace.test:8080',
+      },
+    ];
+
+    const vscodeDir = path.join(workspaceRoot, '.vscode');
+    fs.mkdirSync(vscodeDir, { recursive: true });
+    const settingsPath = path.join(vscodeDir, 'settings.json');
+    const existing = fs.existsSync(settingsPath)
+      ? (JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as Record<string, unknown>)
+      : {};
+    existing['drasiServer.connections'] = workspaceConnections;
+    existing['drasiServer.currentConnectionId'] = 'ws-conn-1';
+    fs.writeFileSync(settingsPath, `${JSON.stringify(existing, null, 2)}\n`);
+
+    // Give VS Code a moment to notice the settings file change.
+    await delay(500);
+
+    const config = vscode.workspace.getConfiguration(SECTION);
+    const before = config.inspect<ServerConnectionConfig[]>('connections');
+    if (!before?.workspaceValue) {
+      // application-scoped settings may hide workspace values from inspect/get.
+      // In that case migration is unnecessary for correctness; skip.
+      this.skip();
+      return;
+    }
+
+    const registry = new ConnectionRegistry();
+    const migrated = await registry.migrateWorkspaceSettingsToGlobal();
+    assert.strictEqual(migrated, true);
+
+    const connectionsInspect = config.inspect<ServerConnectionConfig[]>('connections');
+    const currentIdInspect = config.inspect<string>('currentConnectionId');
+
+    assert.deepStrictEqual(connectionsInspect?.globalValue, workspaceConnections);
+    assert.strictEqual(connectionsInspect?.workspaceValue, undefined);
+    assert.strictEqual(currentIdInspect?.globalValue, 'ws-conn-1');
+    assert.strictEqual(currentIdInspect?.workspaceValue, undefined);
+  });
+});

--- a/dev-tools/vscode/drasi-server/src/test/suite/connection-registry.test.ts
+++ b/dev-tools/vscode/drasi-server/src/test/suite/connection-registry.test.ts
@@ -19,11 +19,10 @@ suite('ConnectionRegistry settings scope', () => {
     await clearConnectionSettings();
   });
 
-  test('writes connections and currentConnectionId to Global, not Workspace', async () => {
-    assert.ok(
-      vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0,
-      'Test host must open a workspace folder'
-    );
+  test('writes connections and currentConnectionId to Global, not Workspace', async function () {
+    if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
+      this.skip();
+    }
 
     const registry = new ConnectionRegistry();
     const connection = await registry.addConnection('Test Server', 'http://example.test:9090');

--- a/dev-tools/vscode/drasi-server/src/test/suite/connection-registry.test.ts
+++ b/dev-tools/vscode/drasi-server/src/test/suite/connection-registry.test.ts
@@ -1,42 +1,13 @@
 import * as assert from 'assert';
-import * as fs from 'fs';
-import * as path from 'path';
 import * as vscode from 'vscode';
 import { ConnectionRegistry, ServerConnectionConfig } from '../../sdk/config';
 
 const SECTION = 'drasiServer';
 
-function delay(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 async function clearConnectionSettings() {
   const config = vscode.workspace.getConfiguration(SECTION);
   await config.update('connections', undefined, vscode.ConfigurationTarget.Global);
   await config.update('currentConnectionId', undefined, vscode.ConfigurationTarget.Global);
-
-  // Best-effort workspace cleanup (may no-op when settings are application-scoped).
-  try {
-    await config.update('connections', undefined, vscode.ConfigurationTarget.Workspace);
-    await config.update('currentConnectionId', undefined, vscode.ConfigurationTarget.Workspace);
-  } catch {
-    // ignore
-  }
-
-  const workspaceRoot = process.env.TEST_WORKSPACE ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-  if (workspaceRoot) {
-    const settingsPath = path.join(workspaceRoot, '.vscode', 'settings.json');
-    if (fs.existsSync(settingsPath)) {
-      try {
-        const raw = JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
-        delete raw['drasiServer.connections'];
-        delete raw['drasiServer.currentConnectionId'];
-        fs.writeFileSync(settingsPath, `${JSON.stringify(raw, null, 2)}\n`);
-      } catch {
-        // ignore corrupt/missing settings during cleanup
-      }
-    }
-  }
 }
 
 suite('ConnectionRegistry settings scope', () => {
@@ -88,61 +59,6 @@ suite('ConnectionRegistry settings scope', () => {
     assert.ok(connectionsInspect?.globalValue && connectionsInspect.globalValue.length > 0);
     assert.strictEqual(connectionsInspect?.workspaceValue, undefined);
     assert.ok(currentIdInspect?.globalValue);
-    assert.strictEqual(currentIdInspect?.workspaceValue, undefined);
-  });
-
-  test('migrateWorkspaceSettingsToGlobal is a no-op when workspace is clean', async () => {
-    const registry = new ConnectionRegistry();
-    const migrated = await registry.migrateWorkspaceSettingsToGlobal();
-    assert.strictEqual(migrated, false);
-  });
-
-  test('migrates workspace connections seeded via settings.json when visible to inspect', async function () {
-    const workspaceRoot = process.env.TEST_WORKSPACE ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-    if (!workspaceRoot) {
-      assert.fail('No workspace root');
-    }
-
-    const workspaceConnections: ServerConnectionConfig[] = [
-      {
-        id: 'ws-conn-1',
-        name: 'Workspace Server',
-        url: 'http://workspace.test:8080',
-      },
-    ];
-
-    const vscodeDir = path.join(workspaceRoot, '.vscode');
-    fs.mkdirSync(vscodeDir, { recursive: true });
-    const settingsPath = path.join(vscodeDir, 'settings.json');
-    const existing = fs.existsSync(settingsPath)
-      ? (JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as Record<string, unknown>)
-      : {};
-    existing['drasiServer.connections'] = workspaceConnections;
-    existing['drasiServer.currentConnectionId'] = 'ws-conn-1';
-    fs.writeFileSync(settingsPath, `${JSON.stringify(existing, null, 2)}\n`);
-
-    // Give VS Code a moment to notice the settings file change.
-    await delay(500);
-
-    const config = vscode.workspace.getConfiguration(SECTION);
-    const before = config.inspect<ServerConnectionConfig[]>('connections');
-    if (!before?.workspaceValue) {
-      // application-scoped settings may hide workspace values from inspect/get.
-      // In that case migration is unnecessary for correctness; skip.
-      this.skip();
-      return;
-    }
-
-    const registry = new ConnectionRegistry();
-    const migrated = await registry.migrateWorkspaceSettingsToGlobal();
-    assert.strictEqual(migrated, true);
-
-    const connectionsInspect = config.inspect<ServerConnectionConfig[]>('connections');
-    const currentIdInspect = config.inspect<string>('currentConnectionId');
-
-    assert.deepStrictEqual(connectionsInspect?.globalValue, workspaceConnections);
-    assert.strictEqual(connectionsInspect?.workspaceValue, undefined);
-    assert.strictEqual(currentIdInspect?.globalValue, 'ws-conn-1');
     assert.strictEqual(currentIdInspect?.workspaceValue, undefined);
   });
 });

--- a/dev-tools/vscode/drasi-server/src/test/suite/server-launcher.test.ts
+++ b/dev-tools/vscode/drasi-server/src/test/suite/server-launcher.test.ts
@@ -1,0 +1,50 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { ServerLauncher } from '../../server-launcher';
+
+const BINARY_PATH_SETTING = 'drasiServer.binaryPath';
+
+async function clearBinaryPathSetting() {
+  await vscode.workspace
+    .getConfiguration()
+    .update(BINARY_PATH_SETTING, undefined, vscode.ConfigurationTarget.Global);
+}
+
+suite('ServerLauncher settings scope', () => {
+  setup(async () => {
+    await clearBinaryPathSetting();
+  });
+
+  teardown(async () => {
+    await clearBinaryPathSetting();
+  });
+
+  test('configureBinary writes binaryPath to Global, not Workspace', async function () {
+    if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
+      this.skip();
+    }
+
+    const selectedPath = '/tmp/drasi-server-test-binary';
+    const originalOpenDialog = vscode.window.showOpenDialog;
+    const originalInfoMessage = vscode.window.showInformationMessage;
+
+    try {
+      (vscode.window as any).showOpenDialog = async () => [vscode.Uri.file(selectedPath)];
+      (vscode.window as any).showInformationMessage = async () => undefined;
+
+      const launcher = new ServerLauncher();
+      await launcher.configureBinary();
+
+      const inspect = vscode.workspace.getConfiguration().inspect<string>(BINARY_PATH_SETTING);
+      assert.strictEqual(inspect?.globalValue, selectedPath);
+      assert.strictEqual(
+        inspect?.workspaceValue,
+        undefined,
+        'binaryPath must not be workspace-scoped'
+      );
+    } finally {
+      (vscode.window as any).showOpenDialog = originalOpenDialog;
+      (vscode.window as any).showInformationMessage = originalInfoMessage;
+    }
+  });
+});


### PR DESCRIPTION
The Drasi VS Code extension was writing personal server connection settings into workspace `.vscode/settings.json` whenever a folder was open. That polluted git status and risked committing developer-specific server URLs.

This change always persists `drasiServer.connections`, `drasiServer.currentConnectionId`, and `drasiServer.binaryPath` with `ConfigurationTarget.Global`, and declares them as `machine` scoped in `package.json` so they stay in user settings and off Settings Sync.

Includes regression tests for Global writes (connections + binary path) and a short README note on user-scoped settings.

No workspace-to-user migration is included: the extension has not been used in production yet, so there is no legacy workspace state to preserve.

Fixes #78