### PR TITLE
Default enable_archive to false for the persistent index provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "drasi-core"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae0da1b998ef09ab1115cc5b8c09b4d82305d8d432961c869db700ef69fbc19"
+checksum = "cc8377915e909144b748f0944d1f024d9ed7931c82b1609520b58f8447ac8813"
 dependencies = [
  "approx",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ drasi-lib = { version = "0.8.9", features = [
 ] }
 
 # Core models (for SourceMiddlewareConfig and other shared types)
-drasi-core = "0.5.7"
+drasi-core = "0.5.8"
 
 # Core bootstrap providers (used by the application API)
 drasi-bootstrap-noop = "0.2.10"
@@ -125,7 +125,7 @@ futures = "0.3"
 tower = { version = "0.4", features = ["util"] }
 hyper = { version = "1.0", features = ["full"] }
 rstest = "0.18"
-drasi-core = "0.5.7"
+drasi-core = "0.5.8"
 
 [lints.rust]
 warnings = "deny"

--- a/src/index_provider.rs
+++ b/src/index_provider.rs
@@ -61,9 +61,8 @@ pub(crate) fn apply_rocksdb_index(builder: DrasiLibBuilder, instance_id: &str) -
         "Enabling persistent indexing for instance '{instance_id}' with RocksDB at: {}",
         index_path.display()
     );
-    let provider = RocksDbIndexProvider::new(
-        index_path, true,  // enable_archive - support for past() function
-        false, // direct_io - use OS page cache
-    );
+    let enable_archive = false; // double-written on every element update, only temporal queries read it
+    let direct_io = false; // use OS page cache
+    let provider = RocksDbIndexProvider::new(index_path, enable_archive, direct_io);
     builder.with_default_index_provider(PERSISTENT_INDEX_PROVIDER_NAME, Arc::new(provider))
 }


### PR DESCRIPTION
# Description

Flips the hardcoded enable_archive from true to false in src/index_provider.rs. The archive column family is double-written on every element update and only temporal queries read it, so most queries pay for an archive they never use.

Hold until drasi-project/drasi-core#699 lands in a released drasi-lib, so temporal reads against the disabled archive fail with a clear error instead of a panic.

Fixes: #151
