### PR TITLE
Fix PR assignment check for Copilot-authored pull requests

### DIFF
--- a/.github/workflows/pr-assignment-check.yml
+++ b/.github/workflows/pr-assignment-check.yml
@@ -26,15 +26,24 @@ jobs:
       issues: write
     steps:
       - name: Check PR has linked issue and author is assigned
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { owner, repo } = context.repo;
             const prNumber = context.payload.pull_request.number;
             const prAuthor = context.payload.pull_request.user.login;
+            const prAuthorType = context.payload.pull_request.user.type;
             const prBody = context.payload.pull_request.body || '';
 
-            console.log(`Checking PR #${prNumber} by @${prAuthor}`);
+            console.log(`Checking PR #${prNumber} by @${prAuthor} (${prAuthorType})`);
+
+            // The assignment policy is for human contributors. GitHub App/bot
+            // authors such as Copilot are not valid usernames for the
+            // collaborator-permission API and cannot be assigned to issues.
+            if (prAuthorType !== 'User') {
+              console.log(`@${prAuthor} has type '${prAuthorType}' - skipping assignment check`);
+              return;
+            }
 
             // Skip check for maintainers (write or admin access)
             const { data: permData } = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -44,7 +53,7 @@ jobs:
             });
             const permission = permData.permission;
             if (permission === 'admin' || permission === 'write') {
-              console.log(`@${prAuthor} has '${permission}' access — skipping assignment check`);
+              console.log(`@${prAuthor} has '${permission}' access - skipping assignment check`);
               return;
             }
 


### PR DESCRIPTION
# Description


Fixes the PR assignment check workflow so it no longer fails when a pull request is authored by Copilot or another non-user GitHub identity.

The workflow previously called GitHub’s collaborator permission API with the PR author login. For Copilot-authored PRs, that login is `Copilot`, which is not a normal GitHub user, causing the API to return `404: Copilot is not a user`.

## Changes

- Upgrade `actions/github-script` from `v7` to `v8`.
- Read `pull_request.user.type` from the PR payload.
- Skip the assignment check for non-`User` authors before calling the collaborator permission API.


## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now.

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
